### PR TITLE
Null pointer dereferences fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.teragrep</groupId>
       <artifactId>akv_01</artifactId>
-      <version>6.0.0</version>
+      <version>6.1.0</version>
     </dependency>
     <!-- tests -->
     <dependency>

--- a/src/main/java/com/teragrep/nlf_01/types/AppInsightType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/AppInsightType.java
@@ -125,12 +125,13 @@ public final class AppInsightType implements EventType {
     @Override
     public Set<SDElement> sdElements() {
         Set<SDElement> elems = new HashSet<>();
-        String time;
+        String time = "";
         try {
-            time = parsedEvent.enqueuedTime().zonedDateTime().toString();
+            if (parsedEvent.enqueuedTime() != null) {
+                time = parsedEvent.enqueuedTime().zonedDateTime().toString();
+            }
         }
-        catch (DateTimeParseException ignored) {
-            time = "";
+        catch (DateTimeParseException | IllegalArgumentException ignored) {
         }
 
         elems

--- a/src/main/java/com/teragrep/nlf_01/types/CLType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/CLType.java
@@ -128,12 +128,13 @@ public final class CLType implements EventType {
     @Override
     public Set<SDElement> sdElements() throws PluginException {
         final Set<SDElement> elems = new HashSet<>();
-        String time;
+        String time = "";
         try {
-            time = parsedEvent.enqueuedTime().zonedDateTime().toString();
+            if (parsedEvent.enqueuedTime() != null) {
+                time = parsedEvent.enqueuedTime().zonedDateTime().toString();
+            }
         }
-        catch (DateTimeParseException ignored) {
-            time = "";
+        catch (DateTimeParseException | IllegalArgumentException ignored) {
         }
 
         elems

--- a/src/main/java/com/teragrep/nlf_01/types/ContainerType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/ContainerType.java
@@ -144,13 +144,15 @@ public final class ContainerType implements EventType {
     @Override
     public Set<SDElement> sdElements() throws PluginException {
         final Set<SDElement> elems = new HashSet<>();
-        String time;
+        String time = "";
         try {
-            time = parsedEvent.enqueuedTime().zonedDateTime().toString();
+            if (parsedEvent.enqueuedTime() != null) {
+                time = parsedEvent.enqueuedTime().zonedDateTime().toString();
+            }
         }
-        catch (DateTimeParseException ignored) {
-            time = "";
+        catch (DateTimeParseException | IllegalArgumentException ignored) {
         }
+
         elems
                 .add(new SDElement("event_id@48577").addSDParam("uuid", UUID.randomUUID().toString()).addSDParam("hostname", new RealHostname("localhost").hostname()).addSDParam("unixtime", Instant.now().toString()).addSDParam("id_source", "aer_02"));
 

--- a/src/main/java/com/teragrep/nlf_01/util/ValidRFC5424Timestamp.java
+++ b/src/main/java/com/teragrep/nlf_01/util/ValidRFC5424Timestamp.java
@@ -65,6 +65,10 @@ public final class ValidRFC5424Timestamp {
      * @return unix epoch, in milliseconds
      */
     public long validTimestamp() throws PluginException {
+        if (uncheckedTimestamp == null) {
+            throw new PluginException("Provided timestamp is null");
+        }
+
         try {
             return Instant.parse(uncheckedTimestamp).toEpochMilli();
         }

--- a/src/test/java/com/teragrep/nlf_01/NLFPluginTest.java
+++ b/src/test/java/com/teragrep/nlf_01/NLFPluginTest.java
@@ -105,6 +105,54 @@ public class NLFPluginTest {
         Assertions.assertEquals(ContainerType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
         Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("2020-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
+    }
+
+    @Test
+    void containerTypeWithNullEnqueuedTime() {
+        final String json = Assertions
+                .assertDoesNotThrow(() -> Files.readString(Paths.get("src/test/resources/container.json")));
+        final ParsedEvent parsedEvent = new EventImpl(
+                json,
+                new HashMap<>(),
+                new HashMap<>(),
+                new HashMap<>(),
+                null,
+                "0"
+        ).parsedEvent();
+
+        final NLFPlugin plugin = new NLFPlugin(new FakeSourceable());
+        final List<SyslogMessage> syslogMessages = Assertions
+                .assertDoesNotThrow(() -> plugin.syslogMessage(parsedEvent));
+        Assertions.assertEquals(1, syslogMessages.size());
+
+        final SyslogMessage syslogMessage = syslogMessages.get(0);
+        Assertions.assertEquals(json, syslogMessage.getMsg());
+        Assertions.assertEquals("HOST-NAME", syslogMessage.getHostname());
+        Assertions.assertEquals("APP-NAME:o", syslogMessage.getAppName());
+        Assertions.assertEquals("2020-01-01T01:23:34.567Z", syslogMessage.getTimestamp());
+
+        final Map<String, Map<String, String>> sdElementMap = syslogMessage
+                .getSDElements()
+                .stream()
+                .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
+
+        Assertions.assertEquals(5, sdElementMap.get("origin@48577").size());
+        Assertions.assertEquals("{subscriptionId}", sdElementMap.get("origin@48577").get("subscription"));
+        Assertions.assertEquals("{resourceName}", sdElementMap.get("origin@48577").get("clusterName"));
+        Assertions.assertEquals("pod-namespace", sdElementMap.get("origin@48577").get("namespace"));
+        Assertions.assertEquals("pod-name", sdElementMap.get("origin@48577").get("pod"));
+        Assertions.assertEquals("container-id", sdElementMap.get("origin@48577").get("containerId"));
+
+        Assertions.assertEquals(1, sdElementMap.get("nlf_01@48577").size());
+        Assertions.assertEquals(ContainerType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+
+        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+
+        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
     }
 
     @Test

--- a/src/test/java/com/teragrep/nlf_01/PropertiesJsonTest.java
+++ b/src/test/java/com/teragrep/nlf_01/PropertiesJsonTest.java
@@ -43,7 +43,8 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-import com.teragrep.nlf_01.PropertiesJson;
+package com.teragrep.nlf_01;
+
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;


### PR DESCRIPTION
check that parsedEvent.enqueuedTime() is not null; catch IllegalArgumentException if zonedDateTime() would result in NPE; add test where enqueuedTime=null; update akv_01 to 6.1.0.; throw PluginException if ValidRFC5424Timestamp would result in NPE