### PR TITLE
Allow SDElement partition names to be configured

### DIFF
--- a/src/main/java/com/teragrep/nlf_01/NLFPlugin.java
+++ b/src/main/java/com/teragrep/nlf_01/NLFPlugin.java
@@ -81,6 +81,7 @@ public final class NLFPlugin implements Plugin {
         final String containerLogHostnameKey = source.source("containerlog.hostname.annotation");
         final String syslogExpectedProcessName = source.source("syslogtype.processname");
         final String realHostname = new RealHostname("localhost").hostname();
+        final String componentNameForPartitions = source.source("component.name");
 
         if (!parsedEvent.isJsonStructure()) {
             // non-applicable
@@ -98,53 +99,55 @@ public final class NLFPlugin implements Plugin {
             jsonObject.containsKey("Type") && jsonObject.get("Type").getValueType().equals(JsonValue.ValueType.STRING)
         ) {
             if (jsonObject.getString("Type").equals("ADFActivityRun")) {
-                eventTypes.add(new ADFActivityRunType(parsedEvent, realHostname));
+                eventTypes.add(new ADFActivityRunType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("ADFPipelineRun")) {
-                eventTypes.add(new ADFPipelineRunType(parsedEvent, realHostname));
+                eventTypes.add(new ADFPipelineRunType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("AppEvents")) {
-                eventTypes.add(new AppEventsType(parsedEvent, realHostname));
+                eventTypes.add(new AppEventsType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("AppServiceConsoleLogs")) {
-                eventTypes.add(new AppServiceConsoleLogsType(parsedEvent, realHostname));
+                eventTypes.add(new AppServiceConsoleLogsType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("AppTraces")) {
-                eventTypes.add(new AppInsightType(parsedEvent, realHostname));
+                eventTypes.add(new AppInsightType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("ContainerAppConsoleLogs")) {
-                eventTypes.add(new ContainerAppConsoleLogsType(parsedEvent, realHostname));
+                eventTypes.add(new ContainerAppConsoleLogsType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("DataverseActivity")) {
-                eventTypes.add(new DataverseActivityType(parsedEvent, realHostname));
+                eventTypes.add(new DataverseActivityType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("FunctionAppLogs")) {
-                eventTypes.add(new FunctionAppLogsType(parsedEvent, realHostname));
+                eventTypes.add(new FunctionAppLogsType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("LogicAppWorkflowRuntime")) {
-                eventTypes.add(new LogicAppWorkflowRuntimeType(parsedEvent, realHostname));
+                eventTypes.add(new LogicAppWorkflowRuntimeType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("PGSQLServerLogs")) {
-                eventTypes.add(new PGSQLServerLogsType(parsedEvent, realHostname));
+                eventTypes.add(new PGSQLServerLogsType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("PowerAutomateActivity")) {
-                eventTypes.add(new PowerAutomateActivityType(parsedEvent, realHostname));
+                eventTypes.add(new PowerAutomateActivityType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("PowerPlatformAdminActivity")) {
-                eventTypes.add(new PowerPlatformAdminActivityType(parsedEvent, realHostname));
+                eventTypes
+                        .add(new PowerPlatformAdminActivityType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").endsWith("fluent_audit_log_events_CL")) {
-                eventTypes.add(new CCType(parsedEvent, realHostname));
+                eventTypes.add(new CCType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").endsWith("_CL")) {
-                eventTypes.add(new CLType(parsedEvent, realHostname));
+                eventTypes.add(new CLType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if (jsonObject.getString("Type").equals("ContainerLogV2")) {
                 if (
                     jsonObject.containsKey("PodNamespace")
                             && jsonObject.getString("PodNamespace").equals("aks-istio-ingress")
                 ) {
-                    eventTypes.add(new IstioIngressContainerType(parsedEvent, realHostname));
+                    eventTypes
+                            .add(new IstioIngressContainerType(parsedEvent, realHostname, componentNameForPartitions));
                 }
                 else {
                     eventTypes
@@ -153,13 +156,22 @@ public final class NLFPlugin implements Plugin {
                                             parsedEvent,
                                             containerLogHostnameKey,
                                             containerLogAppNameKey,
-                                            realHostname
+                                            realHostname,
+                                            componentNameForPartitions
                                     )
                             );
                 }
             }
             else if (jsonObject.getString("Type").equals("Syslog")) {
-                eventTypes.add(new SyslogType(parsedEvent, syslogExpectedProcessName, realHostname));
+                eventTypes
+                        .add(
+                                new SyslogType(
+                                        parsedEvent,
+                                        syslogExpectedProcessName,
+                                        realHostname,
+                                        componentNameForPartitions
+                                )
+                        );
             }
         }
         else if (
@@ -167,7 +179,7 @@ public final class NLFPlugin implements Plugin {
                     && jsonObject.get("AppType").getValueType().equals(JsonValue.ValueType.STRING)
         ) {
             if (jsonObject.getString("AppType").equals("PostgreSQL")) {
-                eventTypes.add(new PostgreSQLType(parsedEvent, realHostname));
+                eventTypes.add(new PostgreSQLType(parsedEvent, realHostname, componentNameForPartitions));
             }
         }
 

--- a/src/main/java/com/teragrep/nlf_01/types/ADFActivityRunType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/ADFActivityRunType.java
@@ -67,10 +67,16 @@ public final class ADFActivityRunType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public ADFActivityRunType(final ParsedEvent parsedEvent, final String realHostname) {
+    public ADFActivityRunType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -110,7 +116,12 @@ public final class ADFActivityRunType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/ADFPipelineRunType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/ADFPipelineRunType.java
@@ -67,10 +67,16 @@ public final class ADFPipelineRunType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public ADFPipelineRunType(final ParsedEvent parsedEvent, final String realHostname) {
+    public ADFPipelineRunType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -112,7 +118,12 @@ public final class ADFPipelineRunType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/AppEventsType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/AppEventsType.java
@@ -67,10 +67,16 @@ public final class AppEventsType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public AppEventsType(final ParsedEvent parsedEvent, final String realHostname) {
+    public AppEventsType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -115,7 +121,12 @@ public final class AppEventsType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/AppInsightType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/AppInsightType.java
@@ -59,10 +59,16 @@ public final class AppInsightType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public AppInsightType(final ParsedEvent parsedEvent, final String realHostname) {
+    public AppInsightType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -105,7 +111,12 @@ public final class AppInsightType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/AppServiceConsoleLogsType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/AppServiceConsoleLogsType.java
@@ -67,10 +67,16 @@ public final class AppServiceConsoleLogsType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public AppServiceConsoleLogsType(final ParsedEvent parsedEvent, final String realHostname) {
+    public AppServiceConsoleLogsType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -110,7 +116,12 @@ public final class AppServiceConsoleLogsType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/CCType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/CCType.java
@@ -71,18 +71,25 @@ public final class CCType implements EventType {
     private final ParsedEvent parsedEvent;
     private final String realHostname;
     private final Pattern appNamePattern;
+    private final String componentNameForPartitions;
 
     /**
      * Parses the appName from data.resourceName's value between the second '=' symbol and the next '/' symbol
      */
-    public CCType(final ParsedEvent parsedEvent, final String realHostname) {
-        this(parsedEvent, realHostname, Pattern.compile("=.*?=(?<value>.*?)(?=/)"));
+    public CCType(final ParsedEvent parsedEvent, final String realHostname, final String componentNameForPartitions) {
+        this(parsedEvent, realHostname, Pattern.compile("=.*?=(?<value>.*?)(?=/)"), componentNameForPartitions);
     }
 
-    private CCType(final ParsedEvent parsedEvent, final String realHostname, final Pattern appNamePattern) {
+    private CCType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final Pattern appNamePattern,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
         this.appNamePattern = appNamePattern;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -138,7 +145,12 @@ public final class CCType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/CLType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/CLType.java
@@ -60,10 +60,12 @@ public final class CLType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public CLType(final ParsedEvent parsedEvent, final String realHostname) {
+    public CLType(final ParsedEvent parsedEvent, final String realHostname, final String componentNameForPartitions) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -112,7 +114,12 @@ public final class CLType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
         final Set<SDElement> elems = defaultSDElements.sdElements();
 
         final JsonObject mainObject = parsedEvent.asJsonStructure().asJsonObject();

--- a/src/main/java/com/teragrep/nlf_01/types/ContainerAppConsoleLogsType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/ContainerAppConsoleLogsType.java
@@ -68,10 +68,16 @@ public final class ContainerAppConsoleLogsType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public ContainerAppConsoleLogsType(final ParsedEvent parsedEvent, final String realHostname) {
+    public ContainerAppConsoleLogsType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -125,7 +131,12 @@ public final class ContainerAppConsoleLogsType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/ContainerType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/ContainerType.java
@@ -62,17 +62,20 @@ public final class ContainerType implements EventType {
     private final String containerLogHostnameKey;
     private final String containerLogAppNameKey;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
     public ContainerType(
             final ParsedEvent parsedEvent,
             final String containerLogHostnameKey,
             final String containerLogAppNameKey,
-            final String realHostname
+            final String realHostname,
+            final String componentNameForPartitions
     ) {
         this.parsedEvent = parsedEvent;
         this.containerLogHostnameKey = containerLogHostnameKey;
         this.containerLogAppNameKey = containerLogAppNameKey;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -156,7 +159,12 @@ public final class ContainerType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
         final Set<SDElement> elems = defaultSDElements.sdElements();
 
         final JsonObject mainObject = parsedEvent.asJsonStructure().asJsonObject();

--- a/src/main/java/com/teragrep/nlf_01/types/DataverseActivityType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/DataverseActivityType.java
@@ -67,10 +67,16 @@ public final class DataverseActivityType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public DataverseActivityType(final ParsedEvent parsedEvent, final String realHostname) {
+    public DataverseActivityType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -119,7 +125,12 @@ public final class DataverseActivityType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/FunctionAppLogsType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/FunctionAppLogsType.java
@@ -67,10 +67,16 @@ public final class FunctionAppLogsType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public FunctionAppLogsType(final ParsedEvent parsedEvent, final String realHostname) {
+    public FunctionAppLogsType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -112,7 +118,12 @@ public final class FunctionAppLogsType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/IstioIngressContainerType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/IstioIngressContainerType.java
@@ -66,19 +66,26 @@ public final class IstioIngressContainerType implements EventType {
     private final String staticAppname;
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public IstioIngressContainerType(final ParsedEvent parsedEvent, final String realHostname) {
-        this("istio-ingress", parsedEvent, realHostname);
+    public IstioIngressContainerType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
+        this("istio-ingress", parsedEvent, realHostname, componentNameForPartitions);
     }
 
     private IstioIngressContainerType(
             final String staticAppname,
             final ParsedEvent parsedEvent,
-            final String realHostname
+            final String realHostname,
+            final String componentNameForPartitions
     ) {
         this.staticAppname = staticAppname;
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -114,7 +121,12 @@ public final class IstioIngressContainerType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
         final Set<SDElement> elems = defaultSDElements.sdElements();
 
         final JsonObject mainObject = parsedEvent.asJsonStructure().asJsonObject();

--- a/src/main/java/com/teragrep/nlf_01/types/LogicAppWorkflowRuntimeType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/LogicAppWorkflowRuntimeType.java
@@ -67,10 +67,16 @@ public final class LogicAppWorkflowRuntimeType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public LogicAppWorkflowRuntimeType(final ParsedEvent parsedEvent, final String realHostname) {
+    public LogicAppWorkflowRuntimeType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -112,7 +118,12 @@ public final class LogicAppWorkflowRuntimeType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/PGSQLServerLogsType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/PGSQLServerLogsType.java
@@ -72,19 +72,26 @@ public final class PGSQLServerLogsType implements EventType {
     private final ParsedEvent parsedEvent;
     private final String realHostname;
     private final Pattern appNamePattern;
+    private final String componentNameForPartitions;
 
-    public PGSQLServerLogsType(final ParsedEvent parsedEvent, final String realHostname) {
-        this(parsedEvent, realHostname, Pattern.compile("^.*?db=(?<dbName>.*?),"));
+    public PGSQLServerLogsType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
+        this(parsedEvent, realHostname, Pattern.compile("^.*?db=(?<dbName>.*?),"), componentNameForPartitions);
     }
 
     private PGSQLServerLogsType(
             final ParsedEvent parsedEvent,
             final String realHostname,
-            final Pattern appNamePattern
+            final Pattern appNamePattern,
+            final String componentNameForPartitions
     ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
         this.appNamePattern = appNamePattern;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -165,10 +172,10 @@ public final class PGSQLServerLogsType implements EventType {
         }
 
         elems
-                .add(new SDElement("aer_02_partition@48577").addSDParam("fully_qualified_namespace", fullyQualifiedNamespace).addSDParam("eventhub_name", eventHubName).addSDParam("partition_id", partitionId).addSDParam("consumer_group", consumerGroup));
+                .add(new SDElement(componentNameForPartitions + "_partition@48577").addSDParam("fully_qualified_namespace", fullyQualifiedNamespace).addSDParam("eventhub_name", eventHubName).addSDParam("partition_id", partitionId).addSDParam("consumer_group", consumerGroup));
 
         elems
-                .add(new SDElement("event_id@48577").addSDParam("uuid", UUID.randomUUID().toString()).addSDParam("hostname", realHostname).addSDParam("unixtime", Instant.now().toString()).addSDParam("id_source", "aer_02"));
+                .add(new SDElement("event_id@48577").addSDParam("uuid", UUID.randomUUID().toString()).addSDParam("hostname", realHostname).addSDParam("unixtime", Instant.now().toString()).addSDParam("id_source", componentNameForPartitions));
 
         final String partitionKey;
         if (!parsedEvent.systemProperties().isStub()) {
@@ -187,10 +194,10 @@ public final class PGSQLServerLogsType implements EventType {
         }
 
         elems
-                .add(new SDElement("aer_02_event@48577").addSDParam("offset", offset).addSDParam("enqueued_time", time).addSDParam("partition_key", partitionKey).addSDParam("properties", new PropertiesJson(parsedEvent.properties()).toJsonObject().toString()));
+                .add(new SDElement(componentNameForPartitions + "_event@48577").addSDParam("offset", offset).addSDParam("enqueued_time", time).addSDParam("partition_key", partitionKey).addSDParam("properties", new PropertiesJson(parsedEvent.properties()).toJsonObject().toString()));
 
         elems
-                .add(new SDElement("aer_02@48577").addSDParam("timestamp_source", time.isEmpty() ? "generated" : "timeEnqueued"));
+                .add(new SDElement(componentNameForPartitions + "@48577").addSDParam("timestamp_source", time.isEmpty() ? "generated" : "timeEnqueued"));
 
         final JsonObject mainObject = parsedEvent.asJsonStructure().asJsonObject();
 

--- a/src/main/java/com/teragrep/nlf_01/types/PostgreSQLType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/PostgreSQLType.java
@@ -62,15 +62,26 @@ public final class PostgreSQLType implements EventType {
     private final ParsedEvent parsedEvent;
     private final String realHostname;
     private final Pattern appNamePattern;
+    private final String componentNameForPartitions;
 
-    public PostgreSQLType(final ParsedEvent parsedEvent, final String realHostname) {
-        this(parsedEvent, realHostname, Pattern.compile("^.*?db=(?<dbName>.*?),"));
+    public PostgreSQLType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
+        this(parsedEvent, realHostname, Pattern.compile("^.*?db=(?<dbName>.*?),"), componentNameForPartitions);
     }
 
-    public PostgreSQLType(final ParsedEvent parsedEvent, final String realHostname, final Pattern appNamePattern) {
+    public PostgreSQLType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final Pattern appNamePattern,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
         this.appNamePattern = appNamePattern;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -125,7 +136,12 @@ public final class PostgreSQLType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/PowerAutomateActivityType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/PowerAutomateActivityType.java
@@ -70,19 +70,31 @@ public final class PowerAutomateActivityType implements EventType {
     private final ParsedEvent parsedEvent;
     private final String realHostname;
     private final Pattern appNamePattern;
+    private final String componentNameForPartitions;
 
-    public PowerAutomateActivityType(final ParsedEvent parsedEvent, final String realHostname) {
-        this(parsedEvent, realHostname, Pattern.compile("/(?<=/environments/)(?<environment>.*?)(?=/flows/)/"));
+    public PowerAutomateActivityType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
+        this(
+                parsedEvent,
+                realHostname,
+                Pattern.compile("/(?<=/environments/)(?<environment>.*?)(?=/flows/)/"),
+                componentNameForPartitions
+        );
     }
 
     public PowerAutomateActivityType(
             final ParsedEvent parsedEvent,
             final String realHostname,
-            final Pattern appNamePattern
+            final Pattern appNamePattern,
+            final String componentNameForPartitions
     ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
         this.appNamePattern = appNamePattern;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -140,7 +152,12 @@ public final class PowerAutomateActivityType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/PowerPlatformAdminActivityType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/PowerPlatformAdminActivityType.java
@@ -67,10 +67,16 @@ public final class PowerPlatformAdminActivityType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
+    private final String componentNameForPartitions;
 
-    public PowerPlatformAdminActivityType(final ParsedEvent parsedEvent, final String realHostname) {
+    public PowerPlatformAdminActivityType(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -118,7 +124,12 @@ public final class PowerPlatformAdminActivityType implements EventType {
 
     @Override
     public Set<SDElement> sdElements() throws PluginException {
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/types/SyslogType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/SyslogType.java
@@ -63,13 +63,20 @@ public final class SyslogType implements EventType {
     private final String expectedProcessName;
     private final String realHostname;
     private final Pattern appNamePattern;
+    private final String componentNameForPartitions;
 
-    public SyslogType(final ParsedEvent parsedEvent, final String expectedProcessName, final String realHostname) {
+    public SyslogType(
+            final ParsedEvent parsedEvent,
+            final String expectedProcessName,
+            final String realHostname,
+            final String componentNameForPartitions
+    ) {
         this(
                 parsedEvent,
                 expectedProcessName,
                 realHostname,
-                Pattern.compile("^.*?(?<uuid>[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})")
+                Pattern.compile("^.*?(?<uuid>[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})"),
+                componentNameForPartitions
         );
     }
 
@@ -77,12 +84,14 @@ public final class SyslogType implements EventType {
             final ParsedEvent parsedEvent,
             final String expectedProcessName,
             final String realHostname,
-            final Pattern appNamePattern
+            final Pattern appNamePattern,
+            final String componentNameForPartitions
     ) {
         this.parsedEvent = parsedEvent;
         this.expectedProcessName = expectedProcessName;
         this.realHostname = realHostname;
         this.appNamePattern = appNamePattern;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     private void validateProcessName() throws PluginException {
@@ -156,7 +165,12 @@ public final class SyslogType implements EventType {
     @Override
     public Set<SDElement> sdElements() throws PluginException {
         validateProcessName();
-        final SDElements defaultSDElements = new DefaultSDElements(parsedEvent, realHostname, this.getClass());
+        final SDElements defaultSDElements = new DefaultSDElements(
+                parsedEvent,
+                realHostname,
+                this.getClass(),
+                componentNameForPartitions
+        );
 
         return defaultSDElements.sdElements();
     }

--- a/src/main/java/com/teragrep/nlf_01/util/DefaultSDElements.java
+++ b/src/main/java/com/teragrep/nlf_01/util/DefaultSDElements.java
@@ -115,7 +115,7 @@ public final class DefaultSDElements implements SDElements {
                 .add(new SDElement(componentNameForPartitions + "_partition@48577").addSDParam("fully_qualified_namespace", fullyQualifiedNamespace).addSDParam("eventhub_name", eventHubName).addSDParam("partition_id", partitionId).addSDParam("consumer_group", consumerGroup));
 
         elems
-                .add(new SDElement("event_id@48577").addSDParam("uuid", UUID.randomUUID().toString()).addSDParam("hostname", realHostname).addSDParam("unixtime", Instant.now().toString()).addSDParam("id_source", "aer"));
+                .add(new SDElement("event_id@48577").addSDParam("uuid", UUID.randomUUID().toString()).addSDParam("hostname", realHostname).addSDParam("unixtime", Instant.now().toString()).addSDParam("id_source", componentNameForPartitions));
 
         final String partitionKey;
         if (!parsedEvent.systemProperties().isStub()) {

--- a/src/main/java/com/teragrep/nlf_01/util/DefaultSDElements.java
+++ b/src/main/java/com/teragrep/nlf_01/util/DefaultSDElements.java
@@ -59,15 +59,27 @@ public final class DefaultSDElements implements SDElements {
     private final ParsedEvent parsedEvent;
     private final String realHostname;
     private final String className;
+    private final String componentNameForPartitions;
 
-    public DefaultSDElements(final ParsedEvent parsedEvent, final String realHostname, final Class<?> inputClass) {
-        this(parsedEvent, realHostname, inputClass.getSimpleName());
+    public DefaultSDElements(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final Class<?> inputClass,
+            final String componentNameForPartitions
+    ) {
+        this(parsedEvent, realHostname, inputClass.getSimpleName(), componentNameForPartitions);
     }
 
-    public DefaultSDElements(final ParsedEvent parsedEvent, final String realHostname, final String className) {
+    public DefaultSDElements(
+            final ParsedEvent parsedEvent,
+            final String realHostname,
+            final String className,
+            final String componentNameForPartitions
+    ) {
         this.parsedEvent = parsedEvent;
         this.realHostname = realHostname;
         this.className = className;
+        this.componentNameForPartitions = componentNameForPartitions;
     }
 
     @Override
@@ -100,10 +112,10 @@ public final class DefaultSDElements implements SDElements {
         }
 
         elems
-                .add(new SDElement("aer_02_partition@48577").addSDParam("fully_qualified_namespace", fullyQualifiedNamespace).addSDParam("eventhub_name", eventHubName).addSDParam("partition_id", partitionId).addSDParam("consumer_group", consumerGroup));
+                .add(new SDElement(componentNameForPartitions + "_partition@48577").addSDParam("fully_qualified_namespace", fullyQualifiedNamespace).addSDParam("eventhub_name", eventHubName).addSDParam("partition_id", partitionId).addSDParam("consumer_group", consumerGroup));
 
         elems
-                .add(new SDElement("event_id@48577").addSDParam("uuid", UUID.randomUUID().toString()).addSDParam("hostname", realHostname).addSDParam("unixtime", Instant.now().toString()).addSDParam("id_source", "aer_02"));
+                .add(new SDElement("event_id@48577").addSDParam("uuid", UUID.randomUUID().toString()).addSDParam("hostname", realHostname).addSDParam("unixtime", Instant.now().toString()).addSDParam("id_source", "aer"));
 
         final String partitionKey;
         if (!parsedEvent.systemProperties().isStub()) {
@@ -122,10 +134,10 @@ public final class DefaultSDElements implements SDElements {
         }
 
         elems
-                .add(new SDElement("aer_02_event@48577").addSDParam("offset", offset).addSDParam("enqueued_time", time).addSDParam("partition_key", partitionKey).addSDParam("properties", new PropertiesJson(parsedEvent.properties()).toJsonObject().toString()));
+                .add(new SDElement(componentNameForPartitions + "_event@48577").addSDParam("offset", offset).addSDParam("enqueued_time", time).addSDParam("partition_key", partitionKey).addSDParam("properties", new PropertiesJson(parsedEvent.properties()).toJsonObject().toString()));
 
         elems
-                .add(new SDElement("aer_02@48577").addSDParam("timestamp_source", time.isEmpty() ? "generated" : "timeEnqueued"));
+                .add(new SDElement(componentNameForPartitions + "@48577").addSDParam("timestamp_source", time.isEmpty() ? "generated" : "timeEnqueued"));
 
         elems.add(new SDElement("nlf_01@48577").addSDParam("eventType", className));
 
@@ -137,14 +149,14 @@ public final class DefaultSDElements implements SDElements {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         final DefaultSDElements that = (DefaultSDElements) o;
-        return Objects.equals(parsedEvent, that.parsedEvent) && Objects.equals(realHostname, that.realHostname)
-                && Objects.equals(className, that.className);
+        return Objects.equals(parsedEvent, that.parsedEvent) && Objects
+                .equals(realHostname, that.realHostname) && Objects.equals(className, that.className)
+                && Objects.equals(componentNameForPartitions, that.componentNameForPartitions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(parsedEvent, realHostname, className);
+        return Objects.hash(parsedEvent, realHostname, className, componentNameForPartitions);
     }
 }

--- a/src/test/java/com/teragrep/nlf_01/NLFPluginTest.java
+++ b/src/test/java/com/teragrep/nlf_01/NLFPluginTest.java
@@ -59,6 +59,7 @@ import com.teragrep.akv_01.event.metadata.systemProperties.EventSystemProperties
 import com.teragrep.akv_01.event.metadata.time.EnqueuedTimeImpl;
 import com.teragrep.akv_01.event.metadata.time.EnqueuedTimeStub;
 import com.teragrep.akv_01.plugin.PluginException;
+import com.teragrep.nlf_01.fakes.ConfigurableSourceable;
 import com.teragrep.nlf_01.fakes.EmptySourceable;
 import com.teragrep.nlf_01.fakes.FakeSourceable;
 import com.teragrep.nlf_01.types.ADFActivityRunType;
@@ -77,6 +78,7 @@ import com.teragrep.nlf_01.types.PostgreSQLType;
 import com.teragrep.nlf_01.types.PowerAutomateActivityType;
 import com.teragrep.nlf_01.types.PowerPlatformAdminActivityType;
 import com.teragrep.nlf_01.types.SyslogType;
+import com.teragrep.nlf_01.util.Sourceable;
 import com.teragrep.rlo_14.SDElement;
 import com.teragrep.rlo_14.SDParam;
 import com.teragrep.rlo_14.SyslogMessage;
@@ -125,10 +127,10 @@ public class NLFPluginTest {
         Assertions.assertEquals(1, sdElementMap.get("nlf_01@48577").size());
         Assertions.assertEquals(ContainerType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
-        Assertions.assertEquals("2020-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
+        Assertions.assertEquals("2020-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
     }
 
     @Test
@@ -166,10 +168,10 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(IstioIngressContainerType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
-        Assertions.assertEquals("2020-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
+        Assertions.assertEquals("2020-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
     }
 
     @Test
@@ -224,10 +226,10 @@ public class NLFPluginTest {
         Assertions.assertEquals(1, sdElementMap.get("nlf_01@48577").size());
         Assertions.assertEquals(ContainerType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
     }
 
     @Test
@@ -282,7 +284,7 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(AppInsightType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -314,10 +316,10 @@ public class NLFPluginTest {
         Assertions.assertEquals(1, sdElementMap.get("nlf_01@48577").size());
         Assertions.assertEquals(CCType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
-        Assertions.assertEquals("2020-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
+        Assertions.assertEquals("2020-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
     }
 
     @Test
@@ -349,7 +351,7 @@ public class NLFPluginTest {
                         sdElementMap.get("origin@48577").get("_ResourceId")
                 );
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -382,10 +384,10 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(ADFPipelineRunType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
-        Assertions.assertEquals("2020-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
+        Assertions.assertEquals("2020-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
     }
 
     @Test
@@ -434,7 +436,7 @@ public class NLFPluginTest {
         Assertions.assertEquals(1, sdElementMap.get("nlf_01@48577").size());
         Assertions.assertEquals(SyslogType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -498,7 +500,7 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(DataverseActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -528,8 +530,8 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(ADFActivityRunType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertEquals(4, sdElementMap.get("aer_02_event@48577").size());
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertEquals(4, sdElementMap.get("aer_event@48577").size());
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -564,8 +566,8 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertEquals(4, sdElementMap.get("aer_02_event@48577").size());
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertEquals(4, sdElementMap.get("aer_event@48577").size());
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -597,8 +599,8 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertEquals(4, sdElementMap.get("aer_02_event@48577").size());
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertEquals(4, sdElementMap.get("aer_event@48577").size());
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -658,7 +660,7 @@ public class NLFPluginTest {
         Assertions.assertEquals(1, sdElementMap.get("nlf_01@48577").size());
         Assertions.assertEquals(AppEventsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -702,7 +704,7 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(AppServiceConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -753,7 +755,7 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(FunctionAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -785,7 +787,7 @@ public class NLFPluginTest {
                         sdElementMap.get("origin@48577").get("_ResourceId")
                 );
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -843,7 +845,7 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(PowerAutomateActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -896,7 +898,7 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(PostgreSQLType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -956,7 +958,7 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(LogicAppWorkflowRuntimeType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -1012,7 +1014,7 @@ public class NLFPluginTest {
         Assertions
                 .assertEquals(PowerPlatformAdminActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
-        Assertions.assertTrue(sdElementMap.get("aer_02_event@48577").containsKey("properties"));
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
     }
 
     @Test
@@ -1101,5 +1103,36 @@ public class NLFPluginTest {
                 .assertThrows(PluginException.class, () -> plugin.syslogMessage(parsedEvent));
         Assertions
                 .assertEquals("jakarta.json.JsonException: Event was not a JSON structure", pluginException.getMessage());
+    }
+
+    @Test
+    void testSyslogMessageWithMissingComponentNameEnvironmentVariable() {
+        final ParsedEvent parsedEvent = new ParsedEventFactory(
+                new UnparsedEventImpl(
+                        "non-json payload",
+                        new EventPartitionContextStub(),
+                        new EventPropertiesStub(),
+                        new EventSystemPropertiesStub(),
+                        new EnqueuedTimeStub(),
+                        new EventOffsetStub()
+                )
+        ).parsedEvent();
+
+        final Map<String, String> envValues = new HashMap<>();
+        envValues.put("containerlog.appname.annotation", "appname");
+        envValues.put("containerlog.hostname.annotation", "appname");
+        envValues.put("syslogtype.processname", "appname");
+
+        final Sourceable sourceable = new ConfigurableSourceable(envValues);
+
+        final NLFPlugin plugin = new NLFPlugin(sourceable);
+        final PluginException pluginException = Assertions
+                .assertThrows(PluginException.class, () -> plugin.syslogMessage(parsedEvent));
+
+        Assertions
+                .assertEquals(
+                        "java.lang.IllegalArgumentException: No such environment variable: component.name",
+                        pluginException.getMessage()
+                );
     }
 }

--- a/src/test/java/com/teragrep/nlf_01/fakes/ConfigurableSourceable.java
+++ b/src/test/java/com/teragrep/nlf_01/fakes/ConfigurableSourceable.java
@@ -47,40 +47,29 @@ package com.teragrep.nlf_01.fakes;
 
 import com.teragrep.akv_01.plugin.PluginException;
 import com.teragrep.nlf_01.util.Sourceable;
+import java.util.Map;
 
-public final class FakeSourceable implements Sourceable {
+public final class ConfigurableSourceable implements Sourceable {
 
-    @Override
+    private final Map<String, String> envValues;
+
+    public ConfigurableSourceable(final Map<String, String> envValues) {
+        this.envValues = envValues;
+    }
+
     public String source(final String name, final String defaultValue) {
-        if (name.equals("containerlog.hostname.annotation")) {
-            return "hostname-annotation";
+        return envValues.getOrDefault(name, defaultValue);
+    }
+
+    public String source(final String name) throws PluginException {
+        if (!envValues.containsKey(name)) {
+            throw new PluginException(new IllegalArgumentException("No such environment variable: " + name));
         }
-        else if (name.equals("containerlog.appname.annotation")) {
-            return "appname-annotation";
-        }
-        else if (name.equals("syslogtype.processname")) {
-            return "Soft-Ware";
-        }
-        else if (name.equals("component.name")) {
-            return "aer";
-        }
-        return defaultValue;
+        return envValues.get(name);
     }
 
     @Override
-    public String source(final String name) throws PluginException {
-        if (name.equals("containerlog.hostname.annotation")) {
-            return "hostname-annotation";
-        }
-        else if (name.equals("containerlog.appname.annotation")) {
-            return "appname-annotation";
-        }
-        else if (name.equals("syslogtype.processname")) {
-            return "Soft-Ware";
-        }
-        else if (name.equals("component.name")) {
-            return "aer";
-        }
-        throw new PluginException(new IllegalArgumentException("No such fake variable: " + name));
+    public String toString() {
+        return "ConfigurableSourceable{" + "envValues=" + envValues + '}';
     }
 }

--- a/src/test/java/com/teragrep/nlf_01/types/ADFActivityRunTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/ADFActivityRunTypeTest.java
@@ -111,7 +111,7 @@ class ADFActivityRunTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final ADFActivityRunType type = new ADFActivityRunType(parsedEvent, "localhost");
+        final ADFActivityRunType type = new ADFActivityRunType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -140,21 +140,21 @@ class ADFActivityRunTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ADFActivityRunType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -167,7 +167,7 @@ class ADFActivityRunTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final ADFActivityRunType type = new ADFActivityRunType(parsedEvent, "localhost");
+        final ADFActivityRunType type = new ADFActivityRunType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -196,17 +196,17 @@ class ADFActivityRunTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ADFActivityRunType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -220,7 +220,7 @@ class ADFActivityRunTypeTest {
                 new EventOffsetStub()
         );
 
-        final ADFActivityRunType type = new ADFActivityRunType(parsedEvent, "localhost");
+        final ADFActivityRunType type = new ADFActivityRunType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -244,17 +244,17 @@ class ADFActivityRunTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ADFActivityRunType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -268,7 +268,7 @@ class ADFActivityRunTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final ADFActivityRunType type = new ADFActivityRunType(parsedEvent, "localhost");
+        final ADFActivityRunType type = new ADFActivityRunType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -277,21 +277,21 @@ class ADFActivityRunTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ADFActivityRunType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));

--- a/src/test/java/com/teragrep/nlf_01/types/ADFPipelineRunTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/ADFPipelineRunTypeTest.java
@@ -115,7 +115,7 @@ class ADFPipelineRunTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final ADFPipelineRunType type = new ADFPipelineRunType(parsedEvent, "localhost");
+        final ADFPipelineRunType type = new ADFPipelineRunType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -144,21 +144,21 @@ class ADFPipelineRunTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ADFPipelineRunType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -171,7 +171,7 @@ class ADFPipelineRunTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final ADFPipelineRunType type = new ADFPipelineRunType(parsedEvent, "localhost");
+        final ADFPipelineRunType type = new ADFPipelineRunType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -200,17 +200,17 @@ class ADFPipelineRunTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ADFPipelineRunType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -224,7 +224,7 @@ class ADFPipelineRunTypeTest {
                 new EventOffsetStub()
         );
 
-        final ADFPipelineRunType type = new ADFPipelineRunType(parsedEvent, "localhost");
+        final ADFPipelineRunType type = new ADFPipelineRunType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -248,17 +248,17 @@ class ADFPipelineRunTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ADFPipelineRunType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -286,7 +286,7 @@ class ADFPipelineRunTypeTest {
                 "src/test/resources/adfpipelinerun.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final ADFPipelineRunType type = new ADFPipelineRunType(parsedEvent, "localhost");
+        final ADFPipelineRunType type = new ADFPipelineRunType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -295,21 +295,21 @@ class ADFPipelineRunTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ADFPipelineRunType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));

--- a/src/test/java/com/teragrep/nlf_01/types/AppEventsTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/AppEventsTypeTest.java
@@ -110,7 +110,7 @@ class AppEventsTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final AppEventsType type = new AppEventsType(parsedEvent, "localhost");
+        final AppEventsType type = new AppEventsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -138,21 +138,21 @@ class AppEventsTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(AppEventsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
@@ -164,7 +164,7 @@ class AppEventsTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final AppEventsType type = new AppEventsType(parsedEvent, "localhost");
+        final AppEventsType type = new AppEventsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -191,17 +191,17 @@ class AppEventsTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(AppEventsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
@@ -214,7 +214,7 @@ class AppEventsTypeTest {
                 new EventOffsetStub()
         );
 
-        final AppEventsType type = new AppEventsType(parsedEvent, "localhost");
+        final AppEventsType type = new AppEventsType(parsedEvent, "localhost", "aer");
 
         // Should throw an Exception since the Type field is missing, but this would probably hinder the actual logic of using this class in a real scenario
         Assertions.assertThrows(PluginException.class, type::appName);
@@ -239,17 +239,17 @@ class AppEventsTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(AppEventsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }

--- a/src/test/java/com/teragrep/nlf_01/types/AppInsightTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/AppInsightTypeTest.java
@@ -119,7 +119,7 @@ public final class AppInsightTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final AppInsightType type = new AppInsightType(parsedEvent, "localhost");
+        final AppInsightType type = new AppInsightType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -147,21 +147,21 @@ public final class AppInsightTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(AppInsightType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -174,7 +174,7 @@ public final class AppInsightTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final AppInsightType type = new AppInsightType(parsedEvent, "localhost");
+        final AppInsightType type = new AppInsightType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -201,17 +201,17 @@ public final class AppInsightTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(AppInsightType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -225,7 +225,7 @@ public final class AppInsightTypeTest {
                 new EventOffsetStub()
         );
 
-        final AppInsightType type = new AppInsightType(parsedEvent, "localhost");
+        final AppInsightType type = new AppInsightType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -249,17 +249,17 @@ public final class AppInsightTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(AppInsightType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -287,7 +287,7 @@ public final class AppInsightTypeTest {
                 "src/test/resources/appinsight_object.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final AppInsightType type = new AppInsightType(parsedEvent, "localhost");
+        final AppInsightType type = new AppInsightType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -296,21 +296,21 @@ public final class AppInsightTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(AppInsightType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));

--- a/src/test/java/com/teragrep/nlf_01/types/AppServiceConsoleLogsTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/AppServiceConsoleLogsTypeTest.java
@@ -115,7 +115,7 @@ class AppServiceConsoleLogsTypeTest {
                 new EventPropertiesFake(), new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final AppServiceConsoleLogsType type = new AppServiceConsoleLogsType(parsedEvent, "localhost");
+        final AppServiceConsoleLogsType type = new AppServiceConsoleLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -143,21 +143,21 @@ class AppServiceConsoleLogsTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(AppServiceConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -171,7 +171,7 @@ class AppServiceConsoleLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final AppServiceConsoleLogsType type = new AppServiceConsoleLogsType(parsedEvent, "localhost");
+        final AppServiceConsoleLogsType type = new AppServiceConsoleLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -198,17 +198,17 @@ class AppServiceConsoleLogsTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(AppServiceConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -222,7 +222,7 @@ class AppServiceConsoleLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final AppServiceConsoleLogsType type = new AppServiceConsoleLogsType(parsedEvent, "localhost");
+        final AppServiceConsoleLogsType type = new AppServiceConsoleLogsType(parsedEvent, "localhost", "aer");
 
         // Should throw an Exception since the Type field is missing, but this would probably hinder the actual logic of using this class in a real scenario
         Assertions.assertThrows(PluginException.class, type::appName);
@@ -247,17 +247,17 @@ class AppServiceConsoleLogsTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(AppServiceConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -285,7 +285,7 @@ class AppServiceConsoleLogsTypeTest {
                 "src/test/resources/appserviceconsolelogs.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final AppServiceConsoleLogsType type = new AppServiceConsoleLogsType(parsedEvent, "localhost");
+        final AppServiceConsoleLogsType type = new AppServiceConsoleLogsType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -294,21 +294,21 @@ class AppServiceConsoleLogsTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(AppServiceConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));

--- a/src/test/java/com/teragrep/nlf_01/types/CCTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/CCTypeTest.java
@@ -115,7 +115,7 @@ class CCTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final EventType type = new CCType(parsedEvent, "localhost");
+        final EventType type = new CCType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -145,21 +145,21 @@ class CCTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(CCType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
@@ -171,7 +171,7 @@ class CCTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final EventType type = new CCType(parsedEvent, "localhost");
+        final EventType type = new CCType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -200,17 +200,17 @@ class CCTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(CCType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
@@ -222,7 +222,7 @@ class CCTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final CCType type = new CCType(parsedEvent, "localhost");
+        final CCType type = new CCType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -246,17 +246,17 @@ class CCTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(CCType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
@@ -274,7 +274,7 @@ class CCTypeTest {
                 new EventOffsetStub()
         );
 
-        final CCType type = new CCType(parsedEvent, "localhost");
+        final CCType type = new CCType(parsedEvent, "localhost", "aer");
 
         final Exception exception = Assertions.assertThrowsExactly(PluginException.class, type::appName);
 
@@ -293,7 +293,7 @@ class CCTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final CCType type = new CCType(parsedEvent, "localhost");
+        final CCType type = new CCType(parsedEvent, "localhost", "aer");
 
         final Exception exception = Assertions.assertThrowsExactly(PluginException.class, type::appName);
 
@@ -322,7 +322,7 @@ class CCTypeTest {
                 "src/test/resources/cc.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final CCType type = new CCType(parsedEvent, "localhost");
+        final CCType type = new CCType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -331,21 +331,21 @@ class CCTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(CCType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }

--- a/src/test/java/com/teragrep/nlf_01/types/CLTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/CLTypeTest.java
@@ -119,7 +119,7 @@ public final class CLTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final CLType type = new CLType(parsedEvent, "localhost");
+        final CLType type = new CLType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -147,21 +147,21 @@ public final class CLTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(
@@ -179,7 +179,7 @@ public final class CLTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final CLType type = new CLType(parsedEvent, "localhost");
+        final CLType type = new CLType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -206,17 +206,17 @@ public final class CLTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(
@@ -234,7 +234,7 @@ public final class CLTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final CLType type = new CLType(parsedEvent, "localhost");
+        final CLType type = new CLType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -277,7 +277,7 @@ public final class CLTypeTest {
                 "src/test/resources/cl.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final CLType type = new CLType(parsedEvent, "localhost");
+        final CLType type = new CLType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -286,21 +286,21 @@ public final class CLTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(CLType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 

--- a/src/test/java/com/teragrep/nlf_01/types/ContainerAppConsoleLogsTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/ContainerAppConsoleLogsTypeTest.java
@@ -115,7 +115,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EventPropertiesFake(), new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost");
+        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -143,21 +143,21 @@ final class ContainerAppConsoleLogsTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -171,7 +171,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EventPropertiesFake(), new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost");
+        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -199,21 +199,21 @@ final class ContainerAppConsoleLogsTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -227,7 +227,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost");
+        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -254,17 +254,17 @@ final class ContainerAppConsoleLogsTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -278,7 +278,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost");
+        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -305,17 +305,17 @@ final class ContainerAppConsoleLogsTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -329,7 +329,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost");
+        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -353,17 +353,17 @@ final class ContainerAppConsoleLogsTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -394,7 +394,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final ContainerAppConsoleLogsType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost");
+        final ContainerAppConsoleLogsType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -403,21 +403,21 @@ final class ContainerAppConsoleLogsTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));

--- a/src/test/java/com/teragrep/nlf_01/types/ContainerTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/ContainerTypeTest.java
@@ -123,7 +123,8 @@ public final class ContainerTypeTest {
                 parsedEvent,
                 "hostname-annotation",
                 "appname-annotation",
-                "localhost"
+                "localhost",
+                "aer"
         );
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
@@ -152,21 +153,21 @@ public final class ContainerTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals("{subscriptionId}", sdElementMap.get("origin@48577").get("subscription"));
         Assertions.assertEquals("{resourceName}", sdElementMap.get("origin@48577").get("clusterName"));
@@ -188,7 +189,8 @@ public final class ContainerTypeTest {
                 parsedEvent,
                 "hostname-annotation",
                 "appname-annotation",
-                "localhost"
+                "localhost",
+                "aer"
         );
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
@@ -216,17 +218,17 @@ public final class ContainerTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals("{subscriptionId}", sdElementMap.get("origin@48577").get("subscription"));
         Assertions.assertEquals("{resourceName}", sdElementMap.get("origin@48577").get("clusterName"));
@@ -249,7 +251,8 @@ public final class ContainerTypeTest {
                 parsedEvent,
                 "hostname-annotation",
                 "appname-annotation",
-                "localhost"
+                "localhost",
+                "aer"
         );
 
         Assertions.assertThrows(PluginException.class, type::appName);
@@ -293,7 +296,7 @@ public final class ContainerTypeTest {
                 "src/test/resources/container.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final ContainerType type = new ContainerType(parsedEvent, "key1", "key2", "localhost");
+        final ContainerType type = new ContainerType(parsedEvent, "key1", "key2", "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -302,21 +305,21 @@ public final class ContainerTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(ContainerType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 

--- a/src/test/java/com/teragrep/nlf_01/types/DataverseActivityTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/DataverseActivityTypeTest.java
@@ -127,7 +127,7 @@ class DataverseActivityTypeTest {
 
         Assertions.assertEquals("DataverseActivity", parsedEvent.asJsonStructure().asJsonObject().getString("Type"));
 
-        final DataverseActivityType type = new DataverseActivityType(parsedEvent, "localhost");
+        final DataverseActivityType type = new DataverseActivityType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -157,21 +157,21 @@ class DataverseActivityTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(DataverseActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -186,7 +186,7 @@ class DataverseActivityTypeTest {
 
         Assertions.assertEquals("DataverseActivity", parsedEvent.asJsonStructure().asJsonObject().getString("Type"));
 
-        final DataverseActivityType type = new DataverseActivityType(parsedEvent, "localhost");
+        final DataverseActivityType type = new DataverseActivityType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -215,17 +215,17 @@ class DataverseActivityTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(DataverseActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -241,7 +241,7 @@ class DataverseActivityTypeTest {
 
         Assertions.assertEquals("DataverseActivity", parsedEvent.asJsonStructure().asJsonObject().getString("Type"));
 
-        final DataverseActivityType type = new DataverseActivityType(parsedEvent, "localhost");
+        final DataverseActivityType type = new DataverseActivityType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -265,17 +265,17 @@ class DataverseActivityTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(DataverseActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));

--- a/src/test/java/com/teragrep/nlf_01/types/FunctionAppLogsTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/FunctionAppLogsTypeTest.java
@@ -115,7 +115,7 @@ class FunctionAppLogsTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final FunctionAppLogsType type = new FunctionAppLogsType(parsedEvent, "localhost");
+        final FunctionAppLogsType type = new FunctionAppLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -143,21 +143,21 @@ class FunctionAppLogsTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(FunctionAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -170,7 +170,7 @@ class FunctionAppLogsTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final FunctionAppLogsType type = new FunctionAppLogsType(parsedEvent, "localhost");
+        final FunctionAppLogsType type = new FunctionAppLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -197,17 +197,17 @@ class FunctionAppLogsTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(FunctionAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -221,7 +221,7 @@ class FunctionAppLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final FunctionAppLogsType type = new FunctionAppLogsType(parsedEvent, "localhost");
+        final FunctionAppLogsType type = new FunctionAppLogsType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -245,17 +245,17 @@ class FunctionAppLogsTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(FunctionAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -283,7 +283,7 @@ class FunctionAppLogsTypeTest {
                 "src/test/resources/function.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final FunctionAppLogsType type = new FunctionAppLogsType(parsedEvent, "localhost");
+        final FunctionAppLogsType type = new FunctionAppLogsType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -292,21 +292,21 @@ class FunctionAppLogsTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(FunctionAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));

--- a/src/test/java/com/teragrep/nlf_01/types/IstioIngressContainerTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/IstioIngressContainerTypeTest.java
@@ -110,7 +110,7 @@ class IstioIngressContainerTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final IstioIngressContainerType type = new IstioIngressContainerType(parsedEvent, "localhost");
+        final IstioIngressContainerType type = new IstioIngressContainerType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -138,21 +138,21 @@ class IstioIngressContainerTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals("{subscriptionId}", sdElementMap.get("origin@48577").get("subscription"));
         Assertions.assertEquals("{resourceName}", sdElementMap.get("origin@48577").get("clusterName"));
@@ -171,7 +171,7 @@ class IstioIngressContainerTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final IstioIngressContainerType type = new IstioIngressContainerType(parsedEvent, "localhost");
+        final IstioIngressContainerType type = new IstioIngressContainerType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -198,17 +198,17 @@ class IstioIngressContainerTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals("{subscriptionId}", sdElementMap.get("origin@48577").get("subscription"));
         Assertions.assertEquals("{resourceName}", sdElementMap.get("origin@48577").get("clusterName"));
@@ -228,7 +228,7 @@ class IstioIngressContainerTypeTest {
                 new EventOffsetStub()
         );
 
-        final IstioIngressContainerType type = new IstioIngressContainerType(parsedEvent, "localhost");
+        final IstioIngressContainerType type = new IstioIngressContainerType(parsedEvent, "localhost", "aer");
 
         Assertions
                 .assertDoesNotThrow(

--- a/src/test/java/com/teragrep/nlf_01/types/LogicAppWorkflowRuntimeTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/LogicAppWorkflowRuntimeTypeTest.java
@@ -115,7 +115,7 @@ final class LogicAppWorkflowRuntimeTypeTest {
                 new EventPropertiesFake(), new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final LogicAppWorkflowRuntimeType type = new LogicAppWorkflowRuntimeType(parsedEvent, "localhost");
+        final LogicAppWorkflowRuntimeType type = new LogicAppWorkflowRuntimeType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -145,21 +145,21 @@ final class LogicAppWorkflowRuntimeTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(LogicAppWorkflowRuntimeType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -173,7 +173,7 @@ final class LogicAppWorkflowRuntimeTypeTest {
                 new EventOffsetStub()
         );
 
-        final LogicAppWorkflowRuntimeType type = new LogicAppWorkflowRuntimeType(parsedEvent, "localhost");
+        final LogicAppWorkflowRuntimeType type = new LogicAppWorkflowRuntimeType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -202,17 +202,17 @@ final class LogicAppWorkflowRuntimeTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(LogicAppWorkflowRuntimeType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -226,7 +226,7 @@ final class LogicAppWorkflowRuntimeTypeTest {
                 new EventOffsetStub()
         );
 
-        final LogicAppWorkflowRuntimeType type = new LogicAppWorkflowRuntimeType(parsedEvent, "localhost");
+        final LogicAppWorkflowRuntimeType type = new LogicAppWorkflowRuntimeType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -250,17 +250,17 @@ final class LogicAppWorkflowRuntimeTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(LogicAppWorkflowRuntimeType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -288,7 +288,7 @@ final class LogicAppWorkflowRuntimeTypeTest {
                 "src/test/resources/logicapp_workflow_runtime.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final LogicAppWorkflowRuntimeType type = new LogicAppWorkflowRuntimeType(parsedEvent, "localhost");
+        final LogicAppWorkflowRuntimeType type = new LogicAppWorkflowRuntimeType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -297,21 +297,21 @@ final class LogicAppWorkflowRuntimeTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(LogicAppWorkflowRuntimeType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));

--- a/src/test/java/com/teragrep/nlf_01/types/PGSQLServerLogsTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/PGSQLServerLogsTypeTest.java
@@ -111,7 +111,7 @@ class PGSQLServerLogsTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final PGSQLServerLogsType type = new PGSQLServerLogsType(parsedEvent, "localhost");
+        final PGSQLServerLogsType type = new PGSQLServerLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -139,21 +139,21 @@ class PGSQLServerLogsTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(
@@ -172,7 +172,7 @@ class PGSQLServerLogsTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final PGSQLServerLogsType type = new PGSQLServerLogsType(parsedEvent, "localhost");
+        final PGSQLServerLogsType type = new PGSQLServerLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -199,17 +199,17 @@ class PGSQLServerLogsTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(
@@ -229,7 +229,7 @@ class PGSQLServerLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final PGSQLServerLogsType type = new PGSQLServerLogsType(parsedEvent, "localhost");
+        final PGSQLServerLogsType type = new PGSQLServerLogsType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -259,7 +259,7 @@ class PGSQLServerLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final PGSQLServerLogsType type = new PGSQLServerLogsType(parsedEvent, "localhost");
+        final PGSQLServerLogsType type = new PGSQLServerLogsType(parsedEvent, "localhost", "aer");
 
         final Exception exception = Assertions.assertThrowsExactly(PluginException.class, type::appName);
         final String expectedExceptionMessage = "Could not parse dbName from Message";
@@ -276,7 +276,7 @@ class PGSQLServerLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final PGSQLServerLogsType type = new PGSQLServerLogsType(parsedEvent, "localhost");
+        final PGSQLServerLogsType type = new PGSQLServerLogsType(parsedEvent, "localhost", "aer");
 
         final Exception exception = Assertions.assertThrowsExactly(PluginException.class, type::appName);
         final String expectedExceptionMessage = "Capture group 'dbName' was not found";

--- a/src/test/java/com/teragrep/nlf_01/types/PostgreSQLTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/PostgreSQLTypeTest.java
@@ -114,7 +114,7 @@ public final class PostgreSQLTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final EventType type = new PostgreSQLType(parsedEvent, "localhost");
+        final EventType type = new PostgreSQLType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -142,21 +142,21 @@ public final class PostgreSQLTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(PostgreSQLType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -169,7 +169,7 @@ public final class PostgreSQLTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final EventType type = new PostgreSQLType(parsedEvent, "localhost");
+        final EventType type = new PostgreSQLType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -196,17 +196,17 @@ public final class PostgreSQLTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(PostgreSQLType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -234,7 +234,7 @@ public final class PostgreSQLTypeTest {
                 "src/test/resources/postgre.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final PostgreSQLType type = new PostgreSQLType(parsedEvent, "localhost");
+        final PostgreSQLType type = new PostgreSQLType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -243,21 +243,21 @@ public final class PostgreSQLTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(PostgreSQLType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));

--- a/src/test/java/com/teragrep/nlf_01/types/PowerAutomateActivityTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/PowerAutomateActivityTypeTest.java
@@ -126,7 +126,7 @@ class PowerAutomateActivityTypeTest {
                 "src/test/resources/powerautomateactivity.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final PowerAutomateActivityType type = new PowerAutomateActivityType(parsedEvent, "localhost");
+        final PowerAutomateActivityType type = new PowerAutomateActivityType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -155,21 +155,21 @@ class PowerAutomateActivityTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(PowerAutomateActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -183,7 +183,7 @@ class PowerAutomateActivityTypeTest {
                 new EventOffsetStub()
         );
 
-        final PowerAutomateActivityType type = new PowerAutomateActivityType(parsedEvent, "localhost");
+        final PowerAutomateActivityType type = new PowerAutomateActivityType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -212,17 +212,17 @@ class PowerAutomateActivityTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(PowerAutomateActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -236,7 +236,7 @@ class PowerAutomateActivityTypeTest {
                 new EventOffsetStub()
         );
 
-        final PowerAutomateActivityType type = new PowerAutomateActivityType(parsedEvent, "localhost");
+        final PowerAutomateActivityType type = new PowerAutomateActivityType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -260,17 +260,17 @@ class PowerAutomateActivityTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(PowerAutomateActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -289,7 +289,7 @@ class PowerAutomateActivityTypeTest {
                 new EventOffsetStub()
         );
 
-        final PowerAutomateActivityType type = new PowerAutomateActivityType(parsedEvent, "localhost");
+        final PowerAutomateActivityType type = new PowerAutomateActivityType(parsedEvent, "localhost", "aer");
 
         final Exception exception = Assertions.assertThrowsExactly(PluginException.class, type::appName);
 
@@ -309,7 +309,7 @@ class PowerAutomateActivityTypeTest {
                 new EventOffsetStub()
         );
 
-        final PowerAutomateActivityType type = new PowerAutomateActivityType(parsedEvent, "localhost");
+        final PowerAutomateActivityType type = new PowerAutomateActivityType(parsedEvent, "localhost", "aer");
 
         final Exception exception = Assertions.assertThrowsExactly(PluginException.class, type::appName);
 

--- a/src/test/java/com/teragrep/nlf_01/types/PowerPlatformAdminActivityTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/PowerPlatformAdminActivityTypeTest.java
@@ -110,7 +110,7 @@ class PowerPlatformAdminActivityTypeTest {
                 new EventPropertiesFake(), new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final PowerPlatformAdminActivityType type = new PowerPlatformAdminActivityType(parsedEvent, "localhost");
+        final PowerPlatformAdminActivityType type = new PowerPlatformAdminActivityType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -139,21 +139,21 @@ class PowerPlatformAdminActivityTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(PowerPlatformAdminActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -167,7 +167,7 @@ class PowerPlatformAdminActivityTypeTest {
                 new EventOffsetStub()
         );
 
-        final PowerPlatformAdminActivityType type = new PowerPlatformAdminActivityType(parsedEvent, "localhost");
+        final PowerPlatformAdminActivityType type = new PowerPlatformAdminActivityType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -196,17 +196,17 @@ class PowerPlatformAdminActivityTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(PowerPlatformAdminActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
@@ -220,7 +220,7 @@ class PowerPlatformAdminActivityTypeTest {
                 new EventOffsetStub()
         );
 
-        final PowerPlatformAdminActivityType type = new PowerPlatformAdminActivityType(parsedEvent, "localhost");
+        final PowerPlatformAdminActivityType type = new PowerPlatformAdminActivityType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -244,17 +244,17 @@ class PowerPlatformAdminActivityTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(PowerPlatformAdminActivityType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));

--- a/src/test/java/com/teragrep/nlf_01/types/SyslogTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/SyslogTypeTest.java
@@ -119,7 +119,7 @@ public final class SyslogTypeTest {
                 new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost");
+        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -147,21 +147,21 @@ public final class SyslogTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(SyslogType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
@@ -173,7 +173,7 @@ public final class SyslogTypeTest {
                 new EventSystemPropertiesStub(), new EnqueuedTimeStub(), new EventOffsetStub()
         );
 
-        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost");
+        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -200,17 +200,17 @@ public final class SyslogTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(SyslogType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
@@ -223,7 +223,7 @@ public final class SyslogTypeTest {
                 new EventOffsetStub()
         );
 
-        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost");
+        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -249,17 +249,17 @@ public final class SyslogTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(SyslogType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
@@ -272,7 +272,7 @@ public final class SyslogTypeTest {
                 new EventOffsetStub()
         );
 
-        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost");
+        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost", "aer");
 
         // All should throw an error because ProcessName is missing from JSON
         Assertions.assertThrows(PluginException.class, type::appName);
@@ -293,7 +293,7 @@ public final class SyslogTypeTest {
                 new EventOffsetStub()
         );
 
-        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost");
+        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -317,17 +317,17 @@ public final class SyslogTypeTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(SyslogType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
@@ -354,7 +354,7 @@ public final class SyslogTypeTest {
                 "src/test/resources/syslog.json", new EventPartitionContextImpl(partitionContextMap), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost");
+        final SyslogType type = new SyslogType(parsedEvent, "Soft-Ware", "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -363,21 +363,21 @@ public final class SyslogTypeTest {
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
         Assertions
-                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("123", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("0", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("456", sdElementMap.get("aer_02_event@48577").get("partition_key"));
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
         Assertions
                 .assertEquals(
                         "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
-                        sdElementMap.get("aer_02_event@48577").get("properties")
+                        sdElementMap.get("aer_event@48577").get("properties")
                 );
 
-        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions.assertEquals(SyslogType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }

--- a/src/test/java/com/teragrep/nlf_01/util/DefaultSDElementsTest.java
+++ b/src/test/java/com/teragrep/nlf_01/util/DefaultSDElementsTest.java
@@ -99,7 +99,8 @@ class DefaultSDElementsTest {
         final SDElements defaultSDElements = new DefaultSDElements(
                 parsedEvent,
                 "hostname",
-                DefaultSDElementsTest.class
+                DefaultSDElementsTest.class,
+                "aer"
         );
 
         final Set<SDElement> sdElements = defaultSDElements.sdElements();
@@ -108,17 +109,17 @@ class DefaultSDElementsTest {
                 .stream()
                 .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("fully_qualified_namespace"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("eventhub_name"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("partition_id"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_partition@48577").get("consumer_group"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
 
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("offset"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("enqueued_time"));
-        Assertions.assertEquals("", sdElementMap.get("aer_02_event@48577").get("partition_key"));
-        Assertions.assertEquals("{}", sdElementMap.get("aer_02_event@48577").get("properties"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
 
-        Assertions.assertEquals("generated", sdElementMap.get("aer_02@48577").get("timestamp_source"));
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
                 .assertEquals(DefaultSDElementsTest.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));


### PR DESCRIPTION
Fixes #74 

- **Now NLF_01 requires `component.name` environment variable to be present when calling NLFPlugin.syslogMessage**
- Added ConfigurableSourceable to be able to test the exception throwing for the change
- Changed mentions of `aer_02` to `aer`

## Description

<!-- Please include a summary of changes made in your pull request. -->

<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods.

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.
