### PR TITLE
Add support for ResourceIds with 11 elements

### DIFF
--- a/src/main/java/com/teragrep/nlf_01/types/SQLSecurityAuditEventsType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/SQLSecurityAuditEventsType.java
@@ -47,16 +47,7 @@ package com.teragrep.nlf_01.types;
 
 import com.teragrep.akv_01.event.ParsedEvent;
 import com.teragrep.akv_01.plugin.PluginException;
-import com.teragrep.nlf_01.util.ASCIIString;
-import com.teragrep.nlf_01.util.DefaultSDElements;
-import com.teragrep.nlf_01.util.MD5Hash;
-import com.teragrep.nlf_01.util.ResourceId;
-import com.teragrep.nlf_01.util.SDElements;
-import com.teragrep.nlf_01.util.ValidKey;
-import com.teragrep.nlf_01.util.ValidRFC5424AppName;
-import com.teragrep.nlf_01.util.ValidRFC5424Hostname;
-import com.teragrep.nlf_01.util.ValidRFC5424Timestamp;
-import com.teragrep.nlf_01.util.ValidStringKey;
+import com.teragrep.nlf_01.util.*;
 import com.teragrep.rlo_14.Facility;
 import com.teragrep.rlo_14.SDElement;
 import com.teragrep.rlo_14.Severity;
@@ -97,7 +88,7 @@ public final class SQLSecurityAuditEventsType implements EventType {
         final ValidKey<String> validKey = new ValidStringKey(record, "resourceId");
 
         return new ValidRFC5424Hostname(
-                "md5-".concat(new MD5Hash(validKey.value()).md5().concat("-").concat(new ASCIIString(new ResourceId(validKey.value()).resourceName()).withNonAsciiCharsRemoved()))
+                "md5-".concat(new MD5Hash(validKey.value()).md5().concat("-").concat(new ASCIIString(new ResourceIdWithSubtype(validKey.value()).resourceName()).withNonAsciiCharsRemoved()))
         ).hostnameWithInvalidCharsRemoved();
     }
 

--- a/src/main/java/com/teragrep/nlf_01/util/ResourceIdWithSubtype.java
+++ b/src/main/java/com/teragrep/nlf_01/util/ResourceIdWithSubtype.java
@@ -1,0 +1,117 @@
+/*
+ * Teragrep Neon log format plugin for AKV_01
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nlf_01.util;
+
+import com.teragrep.akv_01.plugin.PluginException;
+
+import java.util.Arrays;
+
+public final class ResourceIdWithSubtype {
+
+    private final String[] splitResourceId;
+
+    public ResourceIdWithSubtype(final String resourceId) {
+        this(resourceId.split("/"));
+    }
+
+    public ResourceIdWithSubtype(final String[] splitResourceId) {
+        this.splitResourceId = splitResourceId;
+    }
+
+    private void validate() throws PluginException {
+        if (splitResourceId.length != 11) {
+            throw new PluginException(new IllegalArgumentException("ResourceIdWithSubtype must have 11 elements"));
+        }
+    }
+
+    public String subscriptionId() throws PluginException {
+        validate();
+        return splitResourceId[2];
+    }
+
+    public String resourceGroupName() throws PluginException {
+        validate();
+        return splitResourceId[4];
+    }
+
+    public String resourceProviderNamespace() throws PluginException {
+        validate();
+        return splitResourceId[6];
+    }
+
+    public String resourceType() throws PluginException {
+        validate();
+        return splitResourceId[7];
+    }
+
+    public String resourceName() throws PluginException {
+        validate();
+        return splitResourceId[8];
+    }
+
+    public String subtype() throws PluginException {
+        validate();
+        return splitResourceId[9];
+    }
+
+    public String subtypeName() throws PluginException {
+        validate();
+        return splitResourceId[10];
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        final ResourceIdWithSubtype that = (ResourceIdWithSubtype) o;
+        return Arrays.deepEquals(splitResourceId, that.splitResourceId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(splitResourceId);
+    }
+}

--- a/src/main/java/com/teragrep/nlf_01/util/ResourceIdWithSubtype.java
+++ b/src/main/java/com/teragrep/nlf_01/util/ResourceIdWithSubtype.java
@@ -104,8 +104,9 @@ public final class ResourceIdWithSubtype {
 
     @Override
     public boolean equals(final Object o) {
-        if (o == null || getClass() != o.getClass())
+        if (o == null || getClass() != o.getClass()) {
             return false;
+        }
         final ResourceIdWithSubtype that = (ResourceIdWithSubtype) o;
         return Arrays.deepEquals(splitResourceId, that.splitResourceId);
     }

--- a/src/test/java/com/teragrep/nlf_01/NLFPluginTest.java
+++ b/src/test/java/com/teragrep/nlf_01/NLFPluginTest.java
@@ -1037,11 +1037,11 @@ public class NLFPluginTest {
                         "{\n" + "  \"category\": \"SQLSecurityAuditEvents\",\n"
                                 + "  \"operationName\": \"Operation-1\",\n"
                                 + "  \"originalEventTimestamp\": \"2025-10-06T00:00:00.0000000Z\",\n"
-                                + "  \"resourceId\": \"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\"\n"
+                                + "  \"resourceId\": \"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/{resourceSubtype}/{subtypeName}\"\n"
                                 + "}",
                         syslogMessage.getMsg()
                 );
-        Assertions.assertEquals("md5-0ded52ef915af563e25778bf26b0f129-resourceName", syslogMessage.getHostname());
+        Assertions.assertEquals("md5-63a8be7673efd1bb7439550f2ad118ce-resourceName", syslogMessage.getHostname());
         Assertions.assertEquals("Operation-1", syslogMessage.getAppName());
         Assertions.assertEquals("2025-10-06T00:00:00Z", syslogMessage.getTimestamp());
 

--- a/src/test/java/com/teragrep/nlf_01/ResourceIdTest.java
+++ b/src/test/java/com/teragrep/nlf_01/ResourceIdTest.java
@@ -69,7 +69,12 @@ public final class ResourceIdTest {
     @Test
     void testWithInvalidResourceId() {
         final ResourceId r = new ResourceId("/foo/bar");
-        Assertions.assertThrows(PluginException.class, r::subscriptionId);
+        final PluginException subscriptionIdPluginException = Assertions
+                .assertThrows(PluginException.class, r::subscriptionId);
+        final Throwable cause = subscriptionIdPluginException.getCause();
+        Assertions.assertEquals(IllegalArgumentException.class, cause.getClass());
+        Assertions.assertEquals("ResourceId must have 9 elements", cause.getMessage());
+
         Assertions.assertThrows(PluginException.class, r::resourceGroupName);
         Assertions.assertThrows(PluginException.class, r::resourceProviderNamespace);
         Assertions.assertThrows(PluginException.class, r::resourceType);
@@ -81,7 +86,12 @@ public final class ResourceIdTest {
         final ResourceId r = new ResourceId(
                 "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/{resourceSubtype}/{subtypeName}"
         );
-        Assertions.assertThrows(PluginException.class, r::subscriptionId);
+        PluginException subscriptionIdPluginException = Assertions
+                .assertThrows(PluginException.class, r::subscriptionId);
+        final Throwable cause = subscriptionIdPluginException.getCause();
+        Assertions.assertEquals(IllegalArgumentException.class, cause.getClass());
+        Assertions.assertEquals("ResourceId must have 9 elements", cause.getMessage());
+
         Assertions.assertThrows(PluginException.class, r::resourceGroupName);
         Assertions.assertThrows(PluginException.class, r::resourceProviderNamespace);
         Assertions.assertThrows(PluginException.class, r::resourceType);

--- a/src/test/java/com/teragrep/nlf_01/ResourceIdTest.java
+++ b/src/test/java/com/teragrep/nlf_01/ResourceIdTest.java
@@ -75,4 +75,16 @@ public final class ResourceIdTest {
         Assertions.assertThrows(PluginException.class, r::resourceType);
         Assertions.assertThrows(PluginException.class, r::resourceName);
     }
+
+    @Test
+    void testWithLongerResourceId() {
+        final ResourceId r = new ResourceId(
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/{resourceSubtype}/{subtypeName}"
+        );
+        Assertions.assertThrows(PluginException.class, r::subscriptionId);
+        Assertions.assertThrows(PluginException.class, r::resourceGroupName);
+        Assertions.assertThrows(PluginException.class, r::resourceProviderNamespace);
+        Assertions.assertThrows(PluginException.class, r::resourceType);
+        Assertions.assertThrows(PluginException.class, r::resourceName);
+    }
 }

--- a/src/test/java/com/teragrep/nlf_01/types/SQLSecurityAuditEventsTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/SQLSecurityAuditEventsTypeTest.java
@@ -159,10 +159,10 @@ class SQLSecurityAuditEventsTypeTest {
 
         Assertions.assertEquals("Operation-1", actualAppName);
         Assertions.assertEquals(Facility.AUDIT, actualFacility);
-        Assertions.assertEquals("md5-0ded52ef915af563e25778bf26b0f129-resourceName", actualHostname);
+        Assertions.assertEquals("md5-63a8be7673efd1bb7439550f2ad118ce-resourceName", actualHostname);
         Assertions
                 .assertEquals(
-                        "{\"category\":\"SQLSecurityAuditEvents\",\"operationName\":\"Operation-1\",\"originalEventTimestamp\":\"2025-10-06T00:00:00.0000000Z\",\"resourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\"}",
+                        "{\"category\":\"SQLSecurityAuditEvents\",\"operationName\":\"Operation-1\",\"originalEventTimestamp\":\"2025-10-06T00:00:00.0000000Z\",\"resourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/{resourceSubtype}/{subtypeName}\"}",
                         actualMsg
                 );
         Assertions.assertEquals("12345678900", actualMsgId);
@@ -217,10 +217,10 @@ class SQLSecurityAuditEventsTypeTest {
 
         Assertions.assertEquals("Operation-1", actualAppName);
         Assertions.assertEquals(Facility.AUDIT, actualFacility);
-        Assertions.assertEquals("md5-0ded52ef915af563e25778bf26b0f129-resourceName", actualHostname);
+        Assertions.assertEquals("md5-63a8be7673efd1bb7439550f2ad118ce-resourceName", actualHostname);
         Assertions
                 .assertEquals(
-                        "{\"category\":\"SQLSecurityAuditEvents\",\"operationName\":\"Operation-1\",\"originalEventTimestamp\":\"2025-10-06T00:00:00.0000000Z\",\"resourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\"}",
+                        "{\"category\":\"SQLSecurityAuditEvents\",\"operationName\":\"Operation-1\",\"originalEventTimestamp\":\"2025-10-06T00:00:00.0000000Z\",\"resourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/{resourceSubtype}/{subtypeName}\"}",
                         actualMsg
                 );
         Assertions.assertEquals("", actualMsgId);

--- a/src/test/java/com/teragrep/nlf_01/util/ResourceIdWithSubtypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/util/ResourceIdWithSubtypeTest.java
@@ -50,7 +50,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class ResourceIdWithSubtypeTest {
+final class ResourceIdWithSubtypeTest {
 
     @Test
     void equalsContractTest() {

--- a/src/test/java/com/teragrep/nlf_01/util/ResourceIdWithSubtypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/util/ResourceIdWithSubtypeTest.java
@@ -1,0 +1,89 @@
+/*
+ * Teragrep Neon log format plugin for AKV_01
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nlf_01.util;
+
+import com.teragrep.akv_01.plugin.PluginException;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ResourceIdWithSubtypeTest {
+
+    @Test
+    void equalsContractTest() {
+        EqualsVerifier.forClass(ResourceIdWithSubtype.class).verify();
+    }
+
+    @Test
+    void testWithValidResourceId() {
+        final ResourceIdWithSubtype r = new ResourceIdWithSubtype(
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/{resourceSubtype}/{subtypeName}"
+        );
+        Assertions.assertEquals("{subscriptionId}", Assertions.assertDoesNotThrow(r::subscriptionId));
+        Assertions.assertEquals("{resourceGroupName}", Assertions.assertDoesNotThrow(r::resourceGroupName));
+        Assertions
+                .assertEquals("{resourceProviderNamespace}", Assertions.assertDoesNotThrow(r::resourceProviderNamespace));
+        Assertions.assertEquals("{resourceType}", Assertions.assertDoesNotThrow(r::resourceType));
+        Assertions.assertEquals("{resourceName}", Assertions.assertDoesNotThrow(r::resourceName));
+        Assertions.assertEquals("{resourceSubtype}", Assertions.assertDoesNotThrow(r::subtype));
+        Assertions.assertEquals("{subtypeName}", Assertions.assertDoesNotThrow(r::subtypeName));
+    }
+
+    @Test
+    void testWithInvalidResourceId() {
+        // 9 segments long, which shouldn't work with the subtype
+        final ResourceIdWithSubtype r = new ResourceIdWithSubtype(
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
+        );
+        Assertions.assertThrows(PluginException.class, r::subscriptionId);
+        Assertions.assertThrows(PluginException.class, r::resourceGroupName);
+        Assertions.assertThrows(PluginException.class, r::resourceProviderNamespace);
+        Assertions.assertThrows(PluginException.class, r::resourceType);
+        Assertions.assertThrows(PluginException.class, r::resourceName);
+        Assertions.assertThrows(PluginException.class, r::subtype);
+        Assertions.assertThrows(PluginException.class, r::subtypeName);
+    }
+}

--- a/src/test/java/com/teragrep/nlf_01/util/ResourceIdWithSubtypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/util/ResourceIdWithSubtypeTest.java
@@ -78,7 +78,12 @@ final class ResourceIdWithSubtypeTest {
         final ResourceIdWithSubtype r = new ResourceIdWithSubtype(
                 "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
         );
-        Assertions.assertThrows(PluginException.class, r::subscriptionId);
+        final PluginException subscriptionIdPluginException = Assertions
+                .assertThrows(PluginException.class, r::subscriptionId);
+        final Throwable cause = subscriptionIdPluginException.getCause();
+        Assertions.assertEquals(IllegalArgumentException.class, cause.getClass());
+        Assertions.assertEquals("ResourceIdWithSubtype must have 11 elements", cause.getMessage());
+
         Assertions.assertThrows(PluginException.class, r::resourceGroupName);
         Assertions.assertThrows(PluginException.class, r::resourceProviderNamespace);
         Assertions.assertThrows(PluginException.class, r::resourceType);
@@ -92,7 +97,12 @@ final class ResourceIdWithSubtypeTest {
         final ResourceIdWithSubtype r = new ResourceIdWithSubtype(
                 "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/{resourceSubtype}/{subtypeName}/{tooLongId}"
         );
-        Assertions.assertThrows(PluginException.class, r::subscriptionId);
+        final PluginException subscriptionIdPluginException = Assertions
+                .assertThrows(PluginException.class, r::subscriptionId);
+        final Throwable cause = subscriptionIdPluginException.getCause();
+        Assertions.assertEquals(IllegalArgumentException.class, cause.getClass());
+        Assertions.assertEquals("ResourceIdWithSubtype must have 11 elements", cause.getMessage());
+
         Assertions.assertThrows(PluginException.class, r::resourceGroupName);
         Assertions.assertThrows(PluginException.class, r::resourceProviderNamespace);
         Assertions.assertThrows(PluginException.class, r::resourceType);

--- a/src/test/java/com/teragrep/nlf_01/util/ResourceIdWithSubtypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/util/ResourceIdWithSubtypeTest.java
@@ -86,4 +86,18 @@ final class ResourceIdWithSubtypeTest {
         Assertions.assertThrows(PluginException.class, r::subtype);
         Assertions.assertThrows(PluginException.class, r::subtypeName);
     }
+
+    @Test
+    void testWithLongerResourceId() {
+        final ResourceIdWithSubtype r = new ResourceIdWithSubtype(
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/{resourceSubtype}/{subtypeName}/{tooLongId}"
+        );
+        Assertions.assertThrows(PluginException.class, r::subscriptionId);
+        Assertions.assertThrows(PluginException.class, r::resourceGroupName);
+        Assertions.assertThrows(PluginException.class, r::resourceProviderNamespace);
+        Assertions.assertThrows(PluginException.class, r::resourceType);
+        Assertions.assertThrows(PluginException.class, r::resourceName);
+        Assertions.assertThrows(PluginException.class, r::subtype);
+        Assertions.assertThrows(PluginException.class, r::subtypeName);
+    }
 }

--- a/src/test/resources/sqlsecurityauditevents.json
+++ b/src/test/resources/sqlsecurityauditevents.json
@@ -2,5 +2,5 @@
   "category": "SQLSecurityAuditEvents",
   "operationName": "Operation-1",
   "originalEventTimestamp": "2025-10-06T00:00:00.0000000Z",
-  "resourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
+  "resourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}/{resourceSubtype}/{subtypeName}"
 }


### PR DESCRIPTION
## Description
Fixes #84 
<!-- Please include a summary of changes made in your pull request. -->
- Adds the new `ResourceIdWithSubtype` object, which supports Resource IDs with 11 segments
- Tests the new object
- Adds tests to the Exception messages and a longer ResourceID for the 9 segment `ResourceId` object
- Changes `SQLSecurityAuditEventsType` to use the longer `ResourceIdWithSubtype`
<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods.

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.
