### PR TITLE
Add support for ContainerAppSystemLogs

### DIFF
--- a/src/main/java/com/teragrep/nlf_01/NLFPlugin.java
+++ b/src/main/java/com/teragrep/nlf_01/NLFPlugin.java
@@ -125,7 +125,7 @@ public final class NLFPlugin implements Plugin {
             else if ("AzureDiagnostics".equals(type)) {
                 eventTypes.add(new AzureDiagnosticsType(parsedEvent, realHostname, componentNameForPartitions));
             }
-            else if ("ContainerAppConsoleLogs".equals(type)) {
+            else if (Set.of("ContainerAppConsoleLogs", "ContainerAppSystemLogs").contains(type)) {
                 eventTypes.add(new ContainerAppLogsType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if ("DataverseActivity".equals(type)) {

--- a/src/main/java/com/teragrep/nlf_01/NLFPlugin.java
+++ b/src/main/java/com/teragrep/nlf_01/NLFPlugin.java
@@ -126,7 +126,7 @@ public final class NLFPlugin implements Plugin {
                 eventTypes.add(new AzureDiagnosticsType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if ("ContainerAppConsoleLogs".equals(type)) {
-                eventTypes.add(new ContainerAppConsoleLogsType(parsedEvent, realHostname, componentNameForPartitions));
+                eventTypes.add(new ContainerAppLogsType(parsedEvent, realHostname, componentNameForPartitions));
             }
             else if ("DataverseActivity".equals(type)) {
                 eventTypes.add(new DataverseActivityType(parsedEvent, realHostname, componentNameForPartitions));

--- a/src/main/java/com/teragrep/nlf_01/types/ContainerAppLogsType.java
+++ b/src/main/java/com/teragrep/nlf_01/types/ContainerAppLogsType.java
@@ -64,13 +64,13 @@ import com.teragrep.rlo_14.Severity;
 import jakarta.json.JsonObject;
 import java.util.Set;
 
-public final class ContainerAppConsoleLogsType implements EventType {
+public final class ContainerAppLogsType implements EventType {
 
     private final ParsedEvent parsedEvent;
     private final String realHostname;
     private final String componentNameForPartitions;
 
-    public ContainerAppConsoleLogsType(
+    public ContainerAppLogsType(
             final ParsedEvent parsedEvent,
             final String realHostname,
             final String componentNameForPartitions

--- a/src/test/java/com/teragrep/nlf_01/NLFPluginTest.java
+++ b/src/test/java/com/teragrep/nlf_01/NLFPluginTest.java
@@ -919,7 +919,7 @@ public class NLFPluginTest {
 
         Assertions.assertEquals(1, sdElementMap.get("nlf_01@48577").size());
         Assertions
-                .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
         Assertions.assertEquals(4, sdElementMap.get("aer_event@48577").size());
         Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
@@ -952,7 +952,7 @@ public class NLFPluginTest {
 
         Assertions.assertEquals(1, sdElementMap.get("nlf_01@48577").size());
         Assertions
-                .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
 
         Assertions.assertEquals(4, sdElementMap.get("aer_event@48577").size());
         Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));

--- a/src/test/java/com/teragrep/nlf_01/NLFPluginTest.java
+++ b/src/test/java/com/teragrep/nlf_01/NLFPluginTest.java
@@ -926,6 +926,75 @@ public class NLFPluginTest {
     }
 
     @Test
+    void containerAppSystemLogsTypeWithJobName() {
+        final String json = Assertions
+                .assertDoesNotThrow(
+                        () -> Files.readString(Paths.get("src/test/resources/containerappsystemlogswithjobname.json"))
+                );
+        final ParsedEvent parsedEvent = new ParsedEventFactory(
+                new UnparsedEventImpl(json, new EventPartitionContextImpl(new HashMap<>()), new EventPropertiesImpl(new HashMap<>()), new EventSystemPropertiesImpl(new HashMap<>()), new EnqueuedTimeImpl("2020-01-01T00:00:00"), new EventOffsetImpl("0"))
+        ).parsedEvent();
+
+        final NLFPlugin plugin = new NLFPlugin(new FakeSourceable());
+        final List<SyslogMessage> syslogMessages = Assertions
+                .assertDoesNotThrow(() -> plugin.syslogMessage(parsedEvent));
+        Assertions.assertEquals(1, syslogMessages.size());
+
+        final SyslogMessage syslogMessage = syslogMessages.get(0);
+        Assertions.assertEquals("md5-c17ef061422271d0c5a9528446dd144e-resourceName", syslogMessage.getHostname());
+        Assertions.assertEquals("job-1", syslogMessage.getAppName());
+        Assertions.assertEquals("2020-01-01T01:23:34.567Z", syslogMessage.getTimestamp());
+        Assertions.assertEquals(json, syslogMessage.getMsg());
+        final Map<String, Map<String, String>> sdElementMap = syslogMessage
+                .getSDElements()
+                .stream()
+                .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
+
+        Assertions.assertEquals(1, sdElementMap.get("nlf_01@48577").size());
+        Assertions
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+
+        Assertions.assertEquals(4, sdElementMap.get("aer_event@48577").size());
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
+    }
+
+    @Test
+    void containerAppSystemLogsTypeWithContainerAppName() {
+        final String json = Assertions
+                .assertDoesNotThrow(
+                        () -> Files
+                                .readString(
+                                        Paths.get("src/test/resources/containerappsystemlogswithcontainerappname.json")
+                                )
+                );
+        final ParsedEvent parsedEvent = new ParsedEventFactory(
+                new UnparsedEventImpl(json, new EventPartitionContextImpl(new HashMap<>()), new EventPropertiesImpl(new HashMap<>()), new EventSystemPropertiesImpl(new HashMap<>()), new EnqueuedTimeImpl("2020-01-01T00:00:00"), new EventOffsetImpl("0"))
+        ).parsedEvent();
+
+        final NLFPlugin plugin = new NLFPlugin(new FakeSourceable());
+        final List<SyslogMessage> syslogMessages = Assertions
+                .assertDoesNotThrow(() -> plugin.syslogMessage(parsedEvent));
+        Assertions.assertEquals(1, syslogMessages.size());
+
+        final SyslogMessage syslogMessage = syslogMessages.get(0);
+        Assertions.assertEquals("md5-c17ef061422271d0c5a9528446dd144e-resourceName", syslogMessage.getHostname());
+        Assertions.assertEquals("container-app-name", syslogMessage.getAppName());
+        Assertions.assertEquals("2020-01-01T01:23:34.567Z", syslogMessage.getTimestamp());
+        Assertions.assertEquals(json, syslogMessage.getMsg());
+        final Map<String, Map<String, String>> sdElementMap = syslogMessage
+                .getSDElements()
+                .stream()
+                .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
+
+        Assertions.assertEquals(1, sdElementMap.get("nlf_01@48577").size());
+        Assertions
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+
+        Assertions.assertEquals(4, sdElementMap.get("aer_event@48577").size());
+        Assertions.assertTrue(sdElementMap.get("aer_event@48577").containsKey("properties"));
+    }
+
+    @Test
     void containerAppConsoleLogsTypeWithJobName() {
         final String json = Assertions
                 .assertDoesNotThrow(

--- a/src/test/java/com/teragrep/nlf_01/types/ContainerAppConsoleLogsTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/ContainerAppConsoleLogsTypeTest.java
@@ -115,7 +115,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EventPropertiesFake(), new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
+        final EventType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -160,7 +160,7 @@ final class ContainerAppConsoleLogsTypeTest {
         Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
-                .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
 
     @Test
@@ -171,7 +171,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EventPropertiesFake(), new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
+        final EventType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -216,7 +216,7 @@ final class ContainerAppConsoleLogsTypeTest {
         Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
-                .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
 
     @Test
@@ -227,7 +227,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
+        final EventType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -267,7 +267,7 @@ final class ContainerAppConsoleLogsTypeTest {
         Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
-                .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
 
     @Test
@@ -278,7 +278,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
+        final EventType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
 
         final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -318,7 +318,7 @@ final class ContainerAppConsoleLogsTypeTest {
         Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
-                .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
 
     @Test
@@ -329,7 +329,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EventOffsetStub()
         );
 
-        final EventType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
+        final EventType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
 
         Assertions.assertThrows(PluginException.class, type::appName);
         final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
@@ -366,7 +366,7 @@ final class ContainerAppConsoleLogsTypeTest {
         Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
-                .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
 
     @Test
@@ -394,7 +394,7 @@ final class ContainerAppConsoleLogsTypeTest {
                 new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
         );
 
-        final ContainerAppConsoleLogsType type = new ContainerAppConsoleLogsType(parsedEvent, "localhost", "aer");
+        final ContainerAppLogsType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
 
         final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
 
@@ -420,6 +420,6 @@ final class ContainerAppConsoleLogsTypeTest {
         Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
 
         Assertions
-                .assertEquals(ContainerAppConsoleLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
     }
 }

--- a/src/test/java/com/teragrep/nlf_01/types/ContainerAppSystemLogsTypeTest.java
+++ b/src/test/java/com/teragrep/nlf_01/types/ContainerAppSystemLogsTypeTest.java
@@ -1,0 +1,426 @@
+/*
+ * Teragrep Neon log format plugin for AKV_01
+ * Copyright (C) 2025 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.nlf_01.types;
+
+import com.teragrep.akv_01.event.ParsedEvent;
+import com.teragrep.akv_01.event.ParsedEventFactory;
+import com.teragrep.akv_01.event.UnparsedEventImpl;
+import com.teragrep.akv_01.event.metadata.offset.EventOffset;
+import com.teragrep.akv_01.event.metadata.offset.EventOffsetImpl;
+import com.teragrep.akv_01.event.metadata.offset.EventOffsetStub;
+import com.teragrep.akv_01.event.metadata.partitionContext.EventPartitionContext;
+import com.teragrep.akv_01.event.metadata.partitionContext.EventPartitionContextImpl;
+import com.teragrep.akv_01.event.metadata.partitionContext.EventPartitionContextStub;
+import com.teragrep.akv_01.event.metadata.properties.EventProperties;
+import com.teragrep.akv_01.event.metadata.properties.EventPropertiesImpl;
+import com.teragrep.akv_01.event.metadata.properties.EventPropertiesStub;
+import com.teragrep.akv_01.event.metadata.systemProperties.EventSystemProperties;
+import com.teragrep.akv_01.event.metadata.systemProperties.EventSystemPropertiesImpl;
+import com.teragrep.akv_01.event.metadata.systemProperties.EventSystemPropertiesStub;
+import com.teragrep.akv_01.event.metadata.time.EnqueuedTime;
+import com.teragrep.akv_01.event.metadata.time.EnqueuedTimeImpl;
+import com.teragrep.akv_01.event.metadata.time.EnqueuedTimeStub;
+import com.teragrep.akv_01.plugin.PluginException;
+import com.teragrep.nlf_01.fakes.EventPartitionContextFake;
+import com.teragrep.nlf_01.fakes.EventPropertiesFake;
+import com.teragrep.nlf_01.fakes.EventSystemPropertiesFake;
+import com.teragrep.rlo_14.Facility;
+import com.teragrep.rlo_14.SDElement;
+import com.teragrep.rlo_14.SDParam;
+import com.teragrep.rlo_14.Severity;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+final class ContainerAppSystemLogsTypeTest {
+
+    private ParsedEvent testEvent(
+            final String path,
+            final EventPartitionContext partitionCtx,
+            final EventProperties props,
+            final EventSystemProperties sysProps,
+            final EnqueuedTime enqueuedTime,
+            final EventOffset offset
+    ) {
+
+        final InputStream is = Assertions.assertDoesNotThrow(() -> Files.newInputStream(Paths.get(path)));
+        final JsonReader reader = Json.createReader(is);
+        final JsonObject json = reader.readObject();
+
+        Assertions.assertDoesNotThrow(reader::close);
+        Assertions.assertDoesNotThrow(is::close);
+
+        return new ParsedEventFactory(
+                new UnparsedEventImpl(json.toString(), partitionCtx, props, sysProps, enqueuedTime, offset)
+        ).parsedEvent();
+    }
+
+    @Test
+    void testIdealCaseWithContainerAppName() {
+        final ParsedEvent parsedEvent = testEvent(
+                "src/test/resources/containerappsystemlogswithcontainerappname.json", new EventPartitionContextFake(),
+                new EventPropertiesFake(), new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
+        );
+
+        final EventType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
+
+        final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
+        final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
+        final String actualHostname = Assertions.assertDoesNotThrow(type::hostname);
+        final String actualMsg = Assertions.assertDoesNotThrow(type::msg);
+        final String actualMsgId = Assertions.assertDoesNotThrow(type::msgId);
+        final Severity actualSeverity = Assertions.assertDoesNotThrow(type::severity);
+        final Long actualTimestamp = Assertions.assertDoesNotThrow(type::timestamp);
+        final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
+
+        Assertions.assertEquals("container-app-name", actualAppName);
+        Assertions.assertEquals(Facility.AUDIT, actualFacility);
+        Assertions.assertEquals("md5-c17ef061422271d0c5a9528446dd144e-resourceName", actualHostname);
+        Assertions
+                .assertEquals(
+                        "{\"ComponentName\":\"component-1\",\"ComponentType\":\"SpringCloudConfig\",\"ContainerAppName\":\"container-app-name\",\"ContainerName\":\"container-name\",\"Count\":1,\"EnvironmentName\":\"container-app-environment\",\"EventSource\":\"dapr\",\"Location\":\"location-1\",\"Log\":\"log-message\",\"OperationName\":\"job-operation\",\"Reason\":\"reason\",\"ReplicaName\":\"replica-1\",\"RevisionName\":\"revision-1\",\"SourceSystem\":\"Linux\",\"TenantId\":\"456\",\"TimeGenerated\":\"2020-01-01T01:23:34.5678999Z\",\"Type\":\"ContainerAppSystemLogs\",\"_ItemId\":\"123\",\"_Internal_WorkspaceResourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\",\"_ResourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\",\"_SubscriptionId\":\"bb41a487-309b-4d21-9ab8-2a8b948b2d18\"}",
+                        actualMsg
+                );
+        Assertions.assertEquals("12345678900", actualMsgId);
+        Assertions.assertEquals(Severity.NOTICE, actualSeverity);
+        Assertions.assertEquals(1577841814567L, actualTimestamp); // 2020-01-01T01:23:34.5678999Z
+
+        final Map<String, Map<String, String>> sdElementMap = actualSDElements
+                .stream()
+                .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
+
+        Assertions
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
+
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions
+                .assertEquals(
+                        "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
+                        sdElementMap.get("aer_event@48577").get("properties")
+                );
+
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
+
+        Assertions
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+    }
+
+    @Test
+    void testIdealCaseWithJobName() {
+
+        final ParsedEvent parsedEvent = testEvent(
+                "src/test/resources/containerappsystemlogswithjobname.json", new EventPartitionContextFake(),
+                new EventPropertiesFake(), new EventSystemPropertiesFake(), new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
+        );
+
+        final EventType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
+
+        final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
+        final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
+        final String actualHostname = Assertions.assertDoesNotThrow(type::hostname);
+        final String actualMsg = Assertions.assertDoesNotThrow(type::msg);
+        final String actualMsgId = Assertions.assertDoesNotThrow(type::msgId);
+        final Severity actualSeverity = Assertions.assertDoesNotThrow(type::severity);
+        final Long actualTimestamp = Assertions.assertDoesNotThrow(type::timestamp);
+        final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
+
+        Assertions.assertEquals("job-1", actualAppName);
+        Assertions.assertEquals(Facility.AUDIT, actualFacility);
+        Assertions.assertEquals("md5-c17ef061422271d0c5a9528446dd144e-resourceName", actualHostname);
+        Assertions
+                .assertEquals(
+                        "{\"ComponentName\":\"component-1\",\"ComponentType\":\"SpringCloudConfig\",\"ContainerName\":\"container-name\",\"Count\":1,\"EnvironmentName\":\"container-app-environment\",\"EventSource\":\"dapr\",\"JobName\":\"job-1\",\"Location\":\"location-1\",\"Log\":\"log-message\",\"OperationName\":\"job-operation\",\"Reason\":\"reason\",\"ReplicaName\":\"replica-1\",\"RevisionName\":\"revision-1\",\"SourceSystem\":\"Linux\",\"TenantId\":\"456\",\"TimeGenerated\":\"2020-01-01T01:23:34.5678999Z\",\"Type\":\"ContainerAppSystemLogs\",\"_ItemId\":\"123\",\"_Internal_WorkspaceResourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\",\"_ResourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\",\"_SubscriptionId\":\"bb41a487-309b-4d21-9ab8-2a8b948b2d18\"}",
+                        actualMsg
+                );
+        Assertions.assertEquals("12345678900", actualMsgId);
+        Assertions.assertEquals(Severity.NOTICE, actualSeverity);
+        Assertions.assertEquals(1577841814567L, actualTimestamp); // 2020-01-01T01:23:34.5678999Z
+
+        final Map<String, Map<String, String>> sdElementMap = actualSDElements
+                .stream()
+                .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
+
+        Assertions
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
+
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions
+                .assertEquals(
+                        "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
+                        sdElementMap.get("aer_event@48577").get("properties")
+                );
+
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
+
+        Assertions
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+    }
+
+    @Test
+    void testWithAllMetadataStubsWithContainerAppName() {
+        final ParsedEvent parsedEvent = testEvent(
+                "src/test/resources/containerappsystemlogswithcontainerappname.json", new EventPartitionContextStub(),
+                new EventPropertiesStub(), new EventSystemPropertiesStub(), new EnqueuedTimeStub(),
+                new EventOffsetStub()
+        );
+
+        final EventType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
+
+        final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
+        final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
+        final String actualHostname = Assertions.assertDoesNotThrow(type::hostname);
+        final String actualMsg = Assertions.assertDoesNotThrow(type::msg);
+        final String actualMsgId = Assertions.assertDoesNotThrow(type::msgId);
+        final Severity actualSeverity = Assertions.assertDoesNotThrow(type::severity);
+        final Long actualTimestamp = Assertions.assertDoesNotThrow(type::timestamp);
+        final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
+
+        Assertions.assertEquals("container-app-name", actualAppName);
+        Assertions.assertEquals(Facility.AUDIT, actualFacility);
+        Assertions.assertEquals("md5-c17ef061422271d0c5a9528446dd144e-resourceName", actualHostname);
+        Assertions
+                .assertEquals(
+                        "{\"ComponentName\":\"component-1\",\"ComponentType\":\"SpringCloudConfig\",\"ContainerAppName\":\"container-app-name\",\"ContainerName\":\"container-name\",\"Count\":1,\"EnvironmentName\":\"container-app-environment\",\"EventSource\":\"dapr\",\"Location\":\"location-1\",\"Log\":\"log-message\",\"OperationName\":\"job-operation\",\"Reason\":\"reason\",\"ReplicaName\":\"replica-1\",\"RevisionName\":\"revision-1\",\"SourceSystem\":\"Linux\",\"TenantId\":\"456\",\"TimeGenerated\":\"2020-01-01T01:23:34.5678999Z\",\"Type\":\"ContainerAppSystemLogs\",\"_ItemId\":\"123\",\"_Internal_WorkspaceResourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\",\"_ResourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\",\"_SubscriptionId\":\"bb41a487-309b-4d21-9ab8-2a8b948b2d18\"}",
+                        actualMsg
+                );
+        Assertions.assertEquals("", actualMsgId);
+        Assertions.assertEquals(Severity.NOTICE, actualSeverity);
+        Assertions.assertEquals(1577841814567L, actualTimestamp); // 2020-01-01T01:23:34.5678999Z
+
+        final Map<String, Map<String, String>> sdElementMap = actualSDElements
+                .stream()
+                .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
+
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
+
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
+
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
+
+        Assertions
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+    }
+
+    @Test
+    void testWithAllMetadataStubsWithJobName() {
+        final ParsedEvent parsedEvent = testEvent(
+                "src/test/resources/containerappsystemlogswithjobname.json", new EventPartitionContextStub(),
+                new EventPropertiesStub(), new EventSystemPropertiesStub(), new EnqueuedTimeStub(),
+                new EventOffsetStub()
+        );
+
+        final EventType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
+
+        final String actualAppName = Assertions.assertDoesNotThrow(type::appName);
+        final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
+        final String actualHostname = Assertions.assertDoesNotThrow(type::hostname);
+        final String actualMsg = Assertions.assertDoesNotThrow(type::msg);
+        final String actualMsgId = Assertions.assertDoesNotThrow(type::msgId);
+        final Severity actualSeverity = Assertions.assertDoesNotThrow(type::severity);
+        final Long actualTimestamp = Assertions.assertDoesNotThrow(type::timestamp);
+        final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
+
+        Assertions.assertEquals("job-1", actualAppName);
+        Assertions.assertEquals(Facility.AUDIT, actualFacility);
+        Assertions.assertEquals("md5-c17ef061422271d0c5a9528446dd144e-resourceName", actualHostname);
+        Assertions
+                .assertEquals(
+                        "{\"ComponentName\":\"component-1\",\"ComponentType\":\"SpringCloudConfig\",\"ContainerName\":\"container-name\",\"Count\":1,\"EnvironmentName\":\"container-app-environment\",\"EventSource\":\"dapr\",\"JobName\":\"job-1\",\"Location\":\"location-1\",\"Log\":\"log-message\",\"OperationName\":\"job-operation\",\"Reason\":\"reason\",\"ReplicaName\":\"replica-1\",\"RevisionName\":\"revision-1\",\"SourceSystem\":\"Linux\",\"TenantId\":\"456\",\"TimeGenerated\":\"2020-01-01T01:23:34.5678999Z\",\"Type\":\"ContainerAppSystemLogs\",\"_ItemId\":\"123\",\"_Internal_WorkspaceResourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\",\"_ResourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\",\"_SubscriptionId\":\"bb41a487-309b-4d21-9ab8-2a8b948b2d18\"}",
+                        actualMsg
+                );
+        Assertions.assertEquals("", actualMsgId);
+        Assertions.assertEquals(Severity.NOTICE, actualSeverity);
+        Assertions.assertEquals(1577841814567L, actualTimestamp); // 2020-01-01T01:23:34.5678999Z
+
+        final Map<String, Map<String, String>> sdElementMap = actualSDElements
+                .stream()
+                .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
+
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
+
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
+
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
+
+        Assertions
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+    }
+
+    @Test
+    void testWithMissingJsonKeys() {
+        final ParsedEvent parsedEvent = testEvent(
+                "src/test/resources/containerappsystemlogs_missing_keys.json", new EventPartitionContextStub(),
+                new EventPropertiesStub(), new EventSystemPropertiesStub(), new EnqueuedTimeStub(),
+                new EventOffsetStub()
+        );
+
+        final EventType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
+
+        Assertions.assertThrows(PluginException.class, type::appName);
+        final Facility actualFacility = Assertions.assertDoesNotThrow(type::facility);
+        Assertions.assertThrows(PluginException.class, type::hostname);
+        final String actualMsg = Assertions.assertDoesNotThrow(type::msg);
+        final String actualMsgId = Assertions.assertDoesNotThrow(type::msgId);
+        final Severity actualSeverity = Assertions.assertDoesNotThrow(type::severity);
+        Assertions.assertThrows(PluginException.class, type::timestamp);
+        final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
+
+        Assertions.assertEquals(Facility.AUDIT, actualFacility);
+        Assertions
+                .assertEquals(
+                        "{\"ComponentName\":\"component-1\",\"ComponentType\":\"SpringCloudConfig\",\"ContainerName\":\"container-name\",\"Count\":1,\"EnvironmentName\":\"container-app-environment\",\"EventSource\":\"dapr\",\"Location\":\"location-1\",\"Log\":\"log-message\",\"OperationName\":\"job-operation\",\"Reason\":\"reason\",\"ReplicaName\":\"replica-1\",\"RevisionName\":\"revision-1\",\"SourceSystem\":\"Linux\",\"TenantId\":\"456\",\"Type\":\"ContainerAppSystemLogs\",\"_ItemId\":\"123\",\"_Internal_WorkspaceResourceId\":\"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\",\"_SubscriptionId\":\"bb41a487-309b-4d21-9ab8-2a8b948b2d18\"}",
+                        actualMsg
+                );
+        Assertions.assertEquals("", actualMsgId);
+        Assertions.assertEquals(Severity.NOTICE, actualSeverity);
+
+        final Map<String, Map<String, String>> sdElementMap = actualSDElements
+                .stream()
+                .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
+
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("", sdElementMap.get("aer_partition@48577").get("consumer_group"));
+
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions.assertEquals("{}", sdElementMap.get("aer_event@48577").get("properties"));
+
+        Assertions.assertEquals("generated", sdElementMap.get("aer@48577").get("timestamp_source"));
+
+        Assertions
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+    }
+
+    @Test
+    @DisplayName("test sdElement() return value")
+    void testSdElementReturnValue() {
+        final Map<String, Object> partitionContextMap = new HashMap<>();
+        partitionContextMap.put("FullyQualifiedNamespace", "fully-qualified-namespace");
+        partitionContextMap.put("EventHubName", "event-hub-name");
+        partitionContextMap.put("PartitionId", "123");
+        partitionContextMap.put("ConsumerGroup", "consumer-group");
+
+        final Map<String, Object> systemPropertiesMap = new HashMap<>();
+        systemPropertiesMap.put("PartitionKey", "456");
+        systemPropertiesMap.put("SequenceNumber", "12345678900");
+
+        final Map<String, Object> propertiesMap = new HashMap<>();
+        propertiesMap.put("prop-key", "prop-value");
+        propertiesMap.put(null, "important-null-value");
+        propertiesMap.put("important-key", null);
+
+        final ParsedEvent parsedEvent = testEvent(
+                "src/test/resources/containerappsystemlogswithcontainerappname.json", new EventPartitionContextImpl(
+                        partitionContextMap
+                ), new EventPropertiesImpl(propertiesMap), new EventSystemPropertiesImpl(systemPropertiesMap),
+                new EnqueuedTimeImpl("2010-01-01T00:00:00"), new EventOffsetImpl("0")
+        );
+
+        final ContainerAppLogsType type = new ContainerAppLogsType(parsedEvent, "localhost", "aer");
+
+        final Set<SDElement> actualSDElements = Assertions.assertDoesNotThrow(type::sdElements);
+
+        final Map<String, Map<String, String>> sdElementMap = actualSDElements
+                .stream()
+                .collect(Collectors.toMap((SDElement::getSdID), (sdElem) -> sdElem.getSdParams().stream().collect(Collectors.toMap(SDParam::getParamName, SDParam::getParamValue))));
+
+        Assertions
+                .assertEquals("fully-qualified-namespace", sdElementMap.get("aer_partition@48577").get("fully_qualified_namespace"));
+        Assertions.assertEquals("event-hub-name", sdElementMap.get("aer_partition@48577").get("eventhub_name"));
+        Assertions.assertEquals("123", sdElementMap.get("aer_partition@48577").get("partition_id"));
+        Assertions.assertEquals("consumer-group", sdElementMap.get("aer_partition@48577").get("consumer_group"));
+
+        Assertions.assertEquals("0", sdElementMap.get("aer_event@48577").get("offset"));
+        Assertions.assertEquals("2010-01-01T00:00Z", sdElementMap.get("aer_event@48577").get("enqueued_time"));
+        Assertions.assertEquals("456", sdElementMap.get("aer_event@48577").get("partition_key"));
+        Assertions
+                .assertEquals(
+                        "{\"null\":\"important-null-value\",\"prop-key\":\"prop-value\",\"important-key\":null}",
+                        sdElementMap.get("aer_event@48577").get("properties")
+                );
+
+        Assertions.assertEquals("timeEnqueued", sdElementMap.get("aer@48577").get("timestamp_source"));
+
+        Assertions
+                .assertEquals(ContainerAppLogsType.class.getSimpleName(), sdElementMap.get("nlf_01@48577").get("eventType"));
+    }
+}

--- a/src/test/resources/containerappsystemlogs_missing_keys.json
+++ b/src/test/resources/containerappsystemlogs_missing_keys.json
@@ -1,0 +1,20 @@
+{
+  "ComponentName": "component-1",
+  "ComponentType": "SpringCloudConfig",
+  "ContainerName": "container-name",
+  "Count": 1,
+  "EnvironmentName": "container-app-environment",
+  "EventSource": "dapr",
+  "Location": "location-1",
+  "Log": "log-message",
+  "OperationName": "job-operation",
+  "Reason": "reason",
+  "ReplicaName": "replica-1",
+  "RevisionName": "revision-1",
+  "SourceSystem": "Linux",
+  "TenantId": "456",
+  "Type": "ContainerAppSystemLogs",
+  "_ItemId": "123",
+  "_Internal_WorkspaceResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}",
+  "_SubscriptionId": "bb41a487-309b-4d21-9ab8-2a8b948b2d18"
+}

--- a/src/test/resources/containerappsystemlogswithcontainerappname.json
+++ b/src/test/resources/containerappsystemlogswithcontainerappname.json
@@ -1,0 +1,23 @@
+{
+  "ComponentName": "component-1",
+  "ComponentType": "SpringCloudConfig",
+  "ContainerAppName": "container-app-name",
+  "ContainerName": "container-name",
+  "Count": 1,
+  "EnvironmentName": "container-app-environment",
+  "EventSource": "dapr",
+  "Location": "location-1",
+  "Log": "log-message",
+  "OperationName": "job-operation",
+  "Reason": "reason",
+  "ReplicaName": "replica-1",
+  "RevisionName": "revision-1",
+  "SourceSystem": "Linux",
+  "TenantId": "456",
+  "TimeGenerated": "2020-01-01T01:23:34.5678999Z",
+  "Type": "ContainerAppSystemLogs",
+  "_ItemId": "123",
+  "_Internal_WorkspaceResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}",
+  "_ResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}",
+  "_SubscriptionId": "bb41a487-309b-4d21-9ab8-2a8b948b2d18"
+}

--- a/src/test/resources/containerappsystemlogswithjobname.json
+++ b/src/test/resources/containerappsystemlogswithjobname.json
@@ -1,0 +1,23 @@
+{
+  "ComponentName": "component-1",
+  "ComponentType": "SpringCloudConfig",
+  "ContainerName": "container-name",
+  "Count": 1,
+  "EnvironmentName": "container-app-environment",
+  "EventSource": "dapr",
+  "JobName": "job-1",
+  "Location": "location-1",
+  "Log": "log-message",
+  "OperationName": "job-operation",
+  "Reason": "reason",
+  "ReplicaName": "replica-1",
+  "RevisionName": "revision-1",
+  "SourceSystem": "Linux",
+  "TenantId": "456",
+  "TimeGenerated": "2020-01-01T01:23:34.5678999Z",
+  "Type": "ContainerAppSystemLogs",
+  "_ItemId": "123",
+  "_Internal_WorkspaceResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}",
+  "_ResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}",
+  "_SubscriptionId": "bb41a487-309b-4d21-9ab8-2a8b948b2d18"
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of changes made in your pull request. -->

Resolves #106 
- Adds support for the ContainerAppSystemLogs
- Parsed the same way as the existing ContainerAppConsoleLogs
- `ContainerAppSystemLogsType` renamed to `ContainerAppLogsType` to clarify its usage for both of these types

<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods.

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [ ] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.
